### PR TITLE
Initial upload action

### DIFF
--- a/.github/workflows/artifacts.yaml
+++ b/.github/workflows/artifacts.yaml
@@ -13,6 +13,6 @@ jobs:
         uses: google-github-actions/upload-cloud-storage@main
         with:
           credentials: ${{ secrets.GCLOUD_STORAGE_SERVICE_ACCOUNT }}
-          path: packages/nouns-img-permutator/actions_setup
+          path: packages/nouns-img-permutator/assets
           destination: nounsdao.appspot.com
       

--- a/packages/nouns-img-permutator/actions_setup/actionz.txt
+++ b/packages/nouns-img-permutator/actions_setup/actionz.txt
@@ -1,1 +1,0 @@
-Testing 123, is this on?


### PR DESCRIPTION
This adds an initial upload GitHub action that pushes the directory `packages/nouns-img-permutator/actions_setup` up to Google Cloud Storage which currently only contains a test file.