### PR TITLE
Add deployment of `img-permutator-preview/` branches

### DIFF
--- a/.github/workflows/preview-artifacts.yaml
+++ b/.github/workflows/preview-artifacts.yaml
@@ -15,13 +15,10 @@ jobs:
         shell: bash
         run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/img-permutator-preview/})"
         id: extract_branch
-      - name: Echo branch name
-        shell: bash
-        run: echo ${{ steps.extract_branch.outputs.branch }}
-      # - id: upload-files
-      #   uses: google-github-actions/upload-cloud-storage@main
-      #   with:
-      #     credentials: ${{ secrets.GCLOUD_STORAGE_SERVICE_ACCOUNT }}
-      #     path: packages/nouns-img-permutator/assets
-      #     destination: nounsdao.appspot.com
+      - id: upload-files
+        uses: google-github-actions/upload-cloud-storage@main
+        with:
+          credentials: ${{ secrets.GCLOUD_STORAGE_SERVICE_ACCOUNT }}
+          path: packages/nouns-img-permutator/assets
+          destination: nounsdao.appspot.com/${{ steps.extract_branch.outputs.branch }}
       


### PR DESCRIPTION
This PR should add a GitHub Action that will _only_ match branches that start with `img-permutator-preview/`. It will then run a similar push action to copy the assets directory into a named directory based on the branch name.

If the branch name is `img-permutator-preview/carrot` it will push to a directory named `carrot` within the bucket. Assets from that branch should then be accessible at `nounsdao.appspot.com/carrot`.