### PR TITLE
Only run relevant runners

### DIFF
--- a/.github/workflows/bots.yaml
+++ b/.github/workflows/bots.yaml
@@ -5,6 +5,8 @@ on:
     branches:
       - master
   pull_request:
+    paths:
+      - "packages/nouns-bots/**"
     branches:
       - "**"
 

--- a/.github/workflows/contracts.yaml
+++ b/.github/workflows/contracts.yaml
@@ -5,6 +5,9 @@ on:
     branches:
       - master
   pull_request:
+    paths:
+      - "packages/nouns-contracts/**"
+      - "packages/nouns-subgraph/**"
     branches:
       - "**"
 


### PR DESCRIPTION
This PR should change the GitHub actions manifests to they only run the long runners for bot and contract changes.