### PR TITLE
Remove timer jitter

### DIFF
--- a/packages/nouns-webapp/src/components/AuctionTimer/AuctionTimer.module.css
+++ b/packages/nouns-webapp/src/components/AuctionTimer/AuctionTimer.module.css
@@ -19,8 +19,15 @@
   font-family: 'Londrina Solid';
 }
 
-.staticTime {
+.doubleDigitStaticTime {
   min-width: 74px;
+}
+
+.singleDigitStaticTime {
+  min-width: 50px;
+}
+
+.staticTime {
   text-align: right;
 }
 

--- a/packages/nouns-webapp/src/components/AuctionTimer/index.tsx
+++ b/packages/nouns-webapp/src/components/AuctionTimer/index.tsx
@@ -41,6 +41,9 @@ const AuctionTimer: React.FC<{
 
   const auctionContent = auctionEnded ? 'Auction ended' : 'Ends in';
 
+  const flooredMinutes = Math.floor(timerDuration.minutes())
+  const flooredSeconds = Math.floor(timerDuration.seconds())
+
   return (
     <>
       <h2 className={classes.title}>{auction && auctionContent}</h2>
@@ -49,13 +52,17 @@ const AuctionTimer: React.FC<{
           <span className={classes.time}>{auction && `${Math.floor(timerDuration.hours())}h`}</span>
         </div>
         <div className={classes.timerSection}>
-          <span className={clsx(classes.time, classes.staticTime)}>
-            {auction && `${Math.floor(timerDuration.minutes())}m`}
+          <span className={clsx(classes.time, classes.staticTime, (
+            flooredMinutes < 10 ? classes.singleDigitStaticTime : classes.doubleDigitStaticTime
+          ) )}>
+            {auction && `${flooredMinutes}m`}
           </span>
         </div>
         <div className={classes.timerSection}>
-          <span className={clsx(classes.time, classes.staticTime)}>
-            {auction && `${Math.floor(timerDuration.seconds())}s`}
+          <span className={clsx(classes.time, classes.staticTime, (
+            flooredSeconds < 10 ? classes.singleDigitStaticTime : classes.doubleDigitStaticTime
+          ))}>
+            {auction && `${flooredSeconds}s`}
           </span>
         </div>
       </div>


### PR DESCRIPTION
This modifies the layout of the AuctionTimer so that the segments float to the right of their areas. Since the font isn't monospace the segments jump around as time ticks down. This will keep the numbers in a more consistent location.