### PR TITLE
Make history disable-able

### DIFF
--- a/packages/nouns-webapp/src/components/HistoryCollection/index.tsx
+++ b/packages/nouns-webapp/src/components/HistoryCollection/index.tsx
@@ -3,6 +3,7 @@ import Section from '../../layout/Section';
 import classes from './HistoryCollection.module.css';
 import clsx from 'clsx';
 import StandaloneNoun from '../StandaloneNoun';
+import config from '../../config';
 
 interface HistoryCollectionProps {
   historyCount: number;
@@ -23,7 +24,7 @@ const HistoryCollection: React.FC<HistoryCollectionProps> = (props: HistoryColle
   return (
     <Section bgColor="white" fullWidth={true}>
       <div className={clsx(classes.historyCollection, rtl && classes.rtl)}>
-        {nounIds && nounIds.map((nounId, i) => <StandaloneNoun key={i} nounId={nounId} />)}
+        {config.enableHistory && nounIds && nounIds.map((nounId, i) => <StandaloneNoun key={i} nounId={nounId} />)}
       </div>
     </Section>
   );

--- a/packages/nouns-webapp/src/config.ts
+++ b/packages/nouns-webapp/src/config.ts
@@ -5,6 +5,7 @@ interface Config {
   tokenAddress: string;
   nounsDaoAddress: string;
   subgraphApiUri: string;
+  enableHistory: boolean;
 }
 
 type SupportedChains = ChainId.Rinkeby | ChainId.Mainnet;
@@ -17,12 +18,14 @@ const config: Record<SupportedChains, Config> = {
     tokenAddress: '0x632f34c3aee991b10D4b421Bc05413a03d7a37eB',
     nounsDaoAddress: '0xd1C753D9A23eb5c57e0d023e993B9bd4F5086b04',
     subgraphApiUri: 'https://api.thegraph.com/subgraphs/name/nounsdao/nouns-subgraph-rinkeby-v4',
+    enableHistory: process.env.ENABLE_HISTORY === "true" || false
   },
   [ChainId.Mainnet]: {
     auctionProxyAddress: '0x0000000000000000000000000000000000000000',
     tokenAddress: '0x0000000000000000000000000000000000000000',
     nounsDaoAddress: '0x0000000000000000000000000000000000000000',
     subgraphApiUri: 'https://api.thegraph.com/subgraphs/name/nounsdao/nouns-subgraph',
+    enableHistory: process.env.ENABLE_HISTORY === "true" || false
   },
 };
 


### PR DESCRIPTION
This adds an environment variable that must be set to `true` in order to render the history component. This provides a way out of rendering the component which breaks when nouns are burnt.