### PR TITLE
Add breakpoint for history size

### DIFF
--- a/packages/nouns-webapp/src/components/HistoryCollection/HistoryCollection.module.css
+++ b/packages/nouns-webapp/src/components/HistoryCollection/HistoryCollection.module.css
@@ -1,3 +1,8 @@
+@media (max-width: 992px) {
+  .historyCollection {
+    grid-template-columns: repeat(10, 150px);
+  }
+}
 .historyCollection {
   display: grid;
   grid-auto-flow: column dense;
@@ -8,6 +13,7 @@
   overflow-y: hidden;
   overflow-x: hidden;
   overflow: hidden;
+  max-width: 1700px;
 }
 
 .rtl {

--- a/packages/nouns-webapp/src/components/HistoryCollection/index.tsx
+++ b/packages/nouns-webapp/src/components/HistoryCollection/index.tsx
@@ -4,6 +4,7 @@ import classes from './HistoryCollection.module.css';
 import clsx from 'clsx';
 import StandaloneNoun from '../StandaloneNoun';
 import config from '../../config';
+import { Container, Row } from 'react-bootstrap';
 
 interface HistoryCollectionProps {
   historyCount: number;
@@ -24,11 +25,15 @@ const HistoryCollection: React.FC<HistoryCollectionProps> = (props: HistoryColle
 
   return (
     <Section bgColor="white" fullWidth={true}>
-      <div className={clsx(classes.historyCollection, rtl && classes.rtl)}>
-        {config.enableHistory &&
-          nounIds &&
-          nounIds.map((nounId, i) => <StandaloneNoun key={i} nounId={nounId} />)}
-      </div>
+      <Container fluid>
+        <Row className="justify-content-md-center">
+          <div className={clsx(classes.historyCollection, rtl && classes.rtl)}>
+            {config.enableHistory &&
+              nounIds &&
+              nounIds.map((nounId, i) => <StandaloneNoun key={i} nounId={nounId} />)}
+          </div>
+        </Row>
+      </Container>
     </Section>
   );
 };


### PR DESCRIPTION
This creates a breakpoint at 992px (looks like our normal breakpoint) that'll lock the history nouns to 150px wide so they don't get super small. We lose some of them in overflow but IMO that's ok.