### PR TITLE
Add discord redirect

### DIFF
--- a/packages/nouns-webapp/public/_redirects
+++ b/packages/nouns-webapp/public/_redirects
@@ -1,1 +1,2 @@
 /*    /index.html   200
+/discord	https://discord.gg/nouns	302


### PR DESCRIPTION
This adds a redirect from `https://nouns.wtf/discord` to `https://discord.gg/nouns`. While we have a boosted server and can use the vanity URL some people may not understand "discord dot gee-gee"  over spaces. This'll give us the option going forward.