### PR TITLE
Update activity columns for Nounder Nouns

### DIFF
--- a/packages/nouns-webapp/src/components/CurrentBid/index.tsx
+++ b/packages/nouns-webapp/src/components/CurrentBid/index.tsx
@@ -2,7 +2,18 @@ import BigNumber from 'bignumber.js';
 import classes from './CurrentBid.module.css';
 import TruncatedAmount from '../TruncatedAmount';
 
-const CurrentBid: React.FC<{ currentBid: BigNumber; auctionEnded: boolean }> = props => {
+/**
+ * Passible to CurrentBid as `currentBid` prop to indicate that
+ * the bid amount is not applicable to this auction. (Nounder Noun)
+ */
+export const BID_N_A = "N/A";
+
+/**
+ * Special Bid type for not applicable auctions (Nounder Nouns)
+ */
+type BidNa = typeof BID_N_A;
+
+const CurrentBid: React.FC<{ currentBid: BigNumber | BidNa; auctionEnded: boolean }> = props => {
   const { currentBid, auctionEnded } = props;
 
   const titleContent = auctionEnded ? 'Winning bid' : 'Current bid';
@@ -11,7 +22,10 @@ const CurrentBid: React.FC<{ currentBid: BigNumber; auctionEnded: boolean }> = p
     <div className={classes.section}>
       <h4>{titleContent}</h4>
       <h2>
-        <TruncatedAmount amount={currentBid && currentBid} />
+        {
+          currentBid === BID_N_A ? BID_N_A :
+          <TruncatedAmount amount={currentBid && currentBid} />
+        }
       </h2>
     </div>
   );

--- a/packages/nouns-webapp/src/components/NounderNounContent/index.tsx
+++ b/packages/nouns-webapp/src/components/NounderNounContent/index.tsx
@@ -9,6 +9,7 @@ import nounContentClasses from './NounderNounContent.module.css';
 import auctionBidClasses from '../AuctionActivity/BidHistory.module.css';
 import bidBtnClasses from '../BidHistoryBtn//BidHistoryBtn.module.css';
 import auctionActivityClasses from '../AuctionActivity/AuctionActivity.module.css';
+import CurrentBid, { BID_N_A } from '../CurrentBid';
 
 const NounderNounContent: React.FC<{
   mintTimestamp: BigNumber;
@@ -45,9 +46,15 @@ const NounderNounContent: React.FC<{
           </Col>
         </Row>
         <Row className={auctionActivityClasses.activityRow}>
+            <Col lg={5} className={auctionActivityClasses.currentBidCol}>
+              <CurrentBid
+                currentBid={BID_N_A}
+                auctionEnded={true}
+              />
+            </Col>
           <Col lg={5} className={`${auctionActivityClasses.currentBidCol} ${nounContentClasses.currentBidCol}`}>
             <div className={auctionActivityClasses.section}>
-              <h4>Owner</h4>
+              <h4>Winner</h4>
               <h2>
                 nounders.eth
               </h2>
@@ -57,15 +64,14 @@ const NounderNounContent: React.FC<{
       </div>
       <Row className={auctionActivityClasses.activityRow}>
         <Col lg={12}>
-        <ul className={auctionBidClasses.bidCollection}>
-          <li className={`${auctionBidClasses.bidRow} ${nounContentClasses.bidRow}`}>
-            All Noun auction proceeds are sent to the <Link to="vote" className={nounContentClasses.link}>Nouns DAO</Link>. For this reason, we, the project's founders (‘Nounders’) have chosen to compensate ourselves with Nouns. Every 10th Noun for the first 5 years of the project will be sent to our multisig (5/10), where it will be vested and distributed to individual Nounders.
-          </li>
-        </ul>
-
-        <div className={bidBtnClasses.bidHistoryWrapper}>
-            <Link to="nounders" className={bidBtnClasses.bidHistory}>Learn More →</Link>
-        </div>
+          <ul className={auctionBidClasses.bidCollection}>
+            <li className={`${auctionBidClasses.bidRow} ${nounContentClasses.bidRow}`}>
+              All Noun auction proceeds are sent to the <Link to="vote" className={nounContentClasses.link}>Nouns DAO</Link>. For this reason, we, the project's founders (‘Nounders’) have chosen to compensate ourselves with Nouns. Every 10th Noun for the first 5 years of the project will be sent to our multisig (5/10), where it will be vested and distributed to individual Nounders.
+            </li>
+          </ul>
+          <div className={bidBtnClasses.bidHistoryWrapper}>
+              <Link to="nounders" className={bidBtnClasses.bidHistory}>Learn More →</Link>
+          </div>
         </Col>
       </Row>
     </AuctionActivityWrapper>


### PR DESCRIPTION
This changes the Nounder Noun auction view to match 4156's inspector edits.

![unknown](https://user-images.githubusercontent.com/85326879/130896536-0352d122-8185-4041-b007-c3953f2f2030.png)