### PR TITLE
Staging to production

### DIFF
--- a/packages/nouns-bots/src/config.ts
+++ b/packages/nouns-bots/src/config.ts
@@ -9,14 +9,14 @@ export const config = {
   redisPassword: process.env.REDIS_PASSWORD,
   nounsSubgraph:
     process.env.NOUNS_SUBGRAPH_URL ??
-    'https://api.thegraph.com/subgraphs/name/nounsdao/nouns-subgraph-rinkeby',
+    'https://api.thegraph.com/subgraphs/name/nounsdao/nouns-subgraph',
   twitterEnabled: process.env.TWITTER_ENABLED === 'true',
   twitterAppKey: process.env.TWITTER_APP_KEY ?? '',
   twitterAppSecret: process.env.TWITTER_APP_SECRET ?? '',
   twitterAccessToken: process.env.TWITTER_ACCESS_TOKEN ?? '',
   twitterAccessSecret: process.env.TWITTER_ACCESS_SECRET ?? '',
   nounsTokenAddress:
-    process.env.NOUNS_TOKEN_ADDRESS ?? '0xc52bb4Fc4ed72f2a910BF0481D620B927Ded76f7',
+    process.env.NOUNS_TOKEN_ADDRESS ?? '0x9C8fF314C9Bc7F6e59A9d9225Fb22946427eDC03',
   jsonRpcUrl: process.env.JSON_RPC_URL ?? 'http://localhost:8545',
   discordEnabled: process.env.DISCORD_ENABLED === 'true',
   discordWebhookToken: process.env.DISCORD_WEBHOOK_TOKEN ?? '',

--- a/packages/nouns-bots/src/handlers/discord.ts
+++ b/packages/nouns-bots/src/handlers/discord.ts
@@ -35,7 +35,8 @@ export class DiscordAuctionLifecycleHandler implements IAuctionLifecycleHandler 
   async handleNewBid(auctionId: number, bid: Bid) {
     const message = new Discord.MessageEmbed()
       .setTitle(`New Bid Placed`)
-      .setDescription(formatBidMessageText(auctionId, bid))
+      .setURL('https://nouns.wtf')
+      .setDescription(await formatBidMessageText(auctionId, bid))
       .setTimestamp();
     await Promise.all(this.discordClients.map(c => c.send(message)));
     console.log(`processed discord new bid ${auctionId}:${bid.id}`);

--- a/packages/nouns-bots/src/handlers/twitter.ts
+++ b/packages/nouns-bots/src/handlers/twitter.ts
@@ -39,7 +39,7 @@ export class TwitterAuctionLifecycleHandler implements IAuctionLifecycleHandler 
       console.error(`handleNewBid no reply tweet id exists: auction(${auctionId}) bid(${bid.id})`);
       return;
     }
-    const tweet = await twitter.v1.reply(formatBidMessageText(auctionId, bid), tweetReplyId);
+    const tweet = await twitter.v1.reply(await formatBidMessageText(auctionId, bid), tweetReplyId);
     await updateAuctionReplyTweetId(tweet.id_str);
     console.log(`processed twitter new bid ${bid.id}:${auctionId}`);
   }

--- a/packages/nouns-bots/src/subgraph.ts
+++ b/packages/nouns-bots/src/subgraph.ts
@@ -17,6 +17,9 @@ export async function getLastAuctionBids(): Promise<AuctionBids> {
           bids(orderBy: blockNumber, orderDirection: desc, first: 1) {
             id
             amount
+            bidder {
+              id
+            }
           }
         }
       }

--- a/packages/nouns-bots/src/types.ts
+++ b/packages/nouns-bots/src/types.ts
@@ -1,6 +1,11 @@
+export interface Account {
+  id: string;
+}
+
 export interface Bid {
   id: string;
   amount: string;
+  bidder: Account;
 }
 
 export interface AuctionBids {

--- a/packages/nouns-bots/src/utils.ts
+++ b/packages/nouns-bots/src/utils.ts
@@ -1,8 +1,21 @@
 import { ethers } from 'ethers';
 import sharp from 'sharp';
 import { isError, tryF } from 'ts-try';
-import { nounsTokenContract, redis } from './clients';
+import { nounsTokenContract } from './clients';
 import { Bid, TokenMetadata } from './types';
+
+/**
+ * Try to reverse resolve an ENS domain and return it for display,
+ * If no result truncate the address and return it
+ * @param address The address to ENS lookup or format
+ * @returns The resolved ENS lookup domain or a formatted address
+ */
+export async function resolveEnsOrFormatAddress(address: string) {
+  return (
+    (await ethers.getDefaultProvider().lookupAddress(address)) ||
+    `${address.substr(0, 4)}...${address.substr(address.length - 4)}`
+  );
+}
 
 /**
  * Get tweet text for auction started.
@@ -23,8 +36,9 @@ export function formatAuctionStartedTweetText(auctionId: number) {
  * @param bid The amount of the current bid
  * @returns The bid update tweet text
  */
-export function formatBidMessageText(id: number, bid: Bid) {
-  return `Noun ${id} has received a bid of Ξ${ethers.utils.formatEther(bid.amount)}`;
+export async function formatBidMessageText(id: number, bid: Bid) {
+  const bidder = await resolveEnsOrFormatAddress(bid.bidder.id);
+  return `Noun ${id} has received a bid of Ξ${ethers.utils.formatEther(bid.amount)} from ${bidder}`;
 }
 
 /**

--- a/packages/nouns-webapp/public/_redirects
+++ b/packages/nouns-webapp/public/_redirects
@@ -1,1 +1,2 @@
+/discord	https://discord.gg/nouns	302
 /*    /index.html   200

--- a/packages/nouns-webapp/src/components/CurrentBid/index.tsx
+++ b/packages/nouns-webapp/src/components/CurrentBid/index.tsx
@@ -2,7 +2,18 @@ import BigNumber from 'bignumber.js';
 import classes from './CurrentBid.module.css';
 import TruncatedAmount from '../TruncatedAmount';
 
-const CurrentBid: React.FC<{ currentBid: BigNumber; auctionEnded: boolean }> = props => {
+/**
+ * Passible to CurrentBid as `currentBid` prop to indicate that
+ * the bid amount is not applicable to this auction. (Nounder Noun)
+ */
+export const BID_N_A = "n/a";
+
+/**
+ * Special Bid type for not applicable auctions (Nounder Nouns)
+ */
+type BidNa = typeof BID_N_A;
+
+const CurrentBid: React.FC<{ currentBid: BigNumber | BidNa; auctionEnded: boolean }> = props => {
   const { currentBid, auctionEnded } = props;
 
   const titleContent = auctionEnded ? 'Winning bid' : 'Current bid';
@@ -11,7 +22,10 @@ const CurrentBid: React.FC<{ currentBid: BigNumber; auctionEnded: boolean }> = p
     <div className={classes.section}>
       <h4>{titleContent}</h4>
       <h2>
-        <TruncatedAmount amount={currentBid && currentBid} />
+        {
+          currentBid === BID_N_A ? BID_N_A :
+          <TruncatedAmount amount={currentBid && currentBid} />
+        }
       </h2>
     </div>
   );

--- a/packages/nouns-webapp/src/components/NounderNounContent/index.tsx
+++ b/packages/nouns-webapp/src/components/NounderNounContent/index.tsx
@@ -9,6 +9,7 @@ import nounContentClasses from './NounderNounContent.module.css';
 import auctionBidClasses from '../AuctionActivity/BidHistory.module.css';
 import bidBtnClasses from '../BidHistoryBtn//BidHistoryBtn.module.css';
 import auctionActivityClasses from '../AuctionActivity/AuctionActivity.module.css';
+import CurrentBid, { BID_N_A } from '../CurrentBid';
 
 const NounderNounContent: React.FC<{
   mintTimestamp: BigNumber;
@@ -45,9 +46,15 @@ const NounderNounContent: React.FC<{
           </Col>
         </Row>
         <Row className={auctionActivityClasses.activityRow}>
+            <Col lg={5} className={auctionActivityClasses.currentBidCol}>
+              <CurrentBid
+                currentBid={BID_N_A}
+                auctionEnded={true}
+              />
+            </Col>
           <Col lg={5} className={`${auctionActivityClasses.currentBidCol} ${nounContentClasses.currentBidCol}`}>
             <div className={auctionActivityClasses.section}>
-              <h4>Owner</h4>
+              <h4>Winner</h4>
               <h2>
                 nounders.eth
               </h2>
@@ -57,15 +64,14 @@ const NounderNounContent: React.FC<{
       </div>
       <Row className={auctionActivityClasses.activityRow}>
         <Col lg={12}>
-        <ul className={auctionBidClasses.bidCollection}>
-          <li className={`${auctionBidClasses.bidRow} ${nounContentClasses.bidRow}`}>
-            All Noun auction proceeds are sent to the <Link to="vote" className={nounContentClasses.link}>Nouns DAO</Link>. For this reason, we, the project's founders (‘Nounders’) have chosen to compensate ourselves with Nouns. Every 10th Noun for the first 5 years of the project will be sent to our multisig (5/10), where it will be vested and distributed to individual Nounders.
-          </li>
-        </ul>
-
-        <div className={bidBtnClasses.bidHistoryWrapper}>
-            <Link to="nounders" className={bidBtnClasses.bidHistory}>Learn More →</Link>
-        </div>
+          <ul className={auctionBidClasses.bidCollection}>
+            <li className={`${auctionBidClasses.bidRow} ${nounContentClasses.bidRow}`}>
+              All Noun auction proceeds are sent to the <Link to="vote" className={nounContentClasses.link}>Nouns DAO</Link>. For this reason, we, the project's founders (‘Nounders’) have chosen to compensate ourselves with Nouns. Every 10th Noun for the first 5 years of the project will be sent to our multisig (5/10), where it will be vested and distributed to individual Nounders.
+            </li>
+          </ul>
+          <div className={bidBtnClasses.bidHistoryWrapper}>
+              <Link to="nounders" className={bidBtnClasses.bidHistory}>Learn More →</Link>
+          </div>
         </Col>
       </Row>
     </AuctionActivityWrapper>


### PR DESCRIPTION
This will pull production up to staging; deploying the following changes:
* `nouns.wtf/discord` redirect (#195)
* Adjustment to Nounder Noun auction view (#201) 