### PR TITLE
truncate clickable title area & added hover state to homepage FAQ accordion

### DIFF
--- a/packages/nouns-webapp/src/components/Documentation/Documentation.module.css
+++ b/packages/nouns-webapp/src/components/Documentation/Documentation.module.css
@@ -14,6 +14,12 @@
 
 .card {
   border: none;
+  margin-bottom: 2.5rem;
+  max-width: fit-content;
+}
+
+.cardHeader:hover {
+  color: var(--brand-dark-red);
 }
 
 .card,
@@ -26,4 +32,8 @@
   font-family: 'Londrina Solid';
   font-size: 2.5rem;
   cursor: pointer;
+  line-height: normal;
+  padding-top: 0;
+  padding-bottom: 0;
+  max-width: max-content;
 }

--- a/packages/nouns-webapp/src/components/Documentation/index.tsx
+++ b/packages/nouns-webapp/src/components/Documentation/index.tsx
@@ -141,7 +141,7 @@ const Documentation = () => {
                   <li>heads (234) </li>
                   <li>glasses (21)</li>
                 </ul>
-                You can experiment with off-chain noun generation at the {playgroundLink}
+                You can experiment with off-chain noun generation at the {playgroundLink}.
               </Card.Body>
             </Accordion.Collapse>
           </Card>


### PR DESCRIPTION
- title headers hover state to denote action item
- clickable width restricted to width of title vs full div
- removed top/bottom padding, replaced with bottom margin so there’s a non-clickable gap between two items and you’re more likely to know what you’re clicking versus the clickable divs running right to each other
- add missing period to final sentence in Noun Traits section

https://user-images.githubusercontent.com/26611339/132537393-f984de2e-ea54-4ecc-ba63-89241104c177.mov

