### PR TITLE
Update timer logic to check auction status less frequently

### DIFF
--- a/packages/nouns-webapp/src/components/AuctionActivity/index.tsx
+++ b/packages/nouns-webapp/src/components/AuctionActivity/index.tsx
@@ -61,7 +61,7 @@ const AuctionActivity: React.FC<AuctionActivityProps> = (props: AuctionActivityP
     </h1>
   );
 
-  // timer logic
+  // timer logic - check auction every 30 seconds, until final minute, then every second
   useEffect(() => {
     if (!auction) return;
 
@@ -71,9 +71,12 @@ const AuctionActivity: React.FC<AuctionActivityProps> = (props: AuctionActivityP
       setAuctionEnded(true);
     } else {
       setAuctionEnded(false);
-      const timer = setTimeout(() => {
-        setAuctionTimer(!auctionTimer);
-      }, 1000);
+      const timer = setTimeout(
+        () => {
+          setAuctionTimer(!auctionTimer);
+        },
+        timeLeft > 60 ? 30000 : 1000,
+      );
 
       return () => {
         clearTimeout(timer);


### PR DESCRIPTION
Update timer logic to check auction status less frequently for react performance improvement. This was causing performance issues in party nouns.
Check auction status once every 30 seconds to prevent unnecessary react re-renders. Then check every second in the final minute of the auction.