### PR TITLE
Fix documentation title width

### DIFF
--- a/packages/nouns-webapp/src/components/Documentation/Documentation.module.css
+++ b/packages/nouns-webapp/src/components/Documentation/Documentation.module.css
@@ -35,5 +35,4 @@
   line-height: normal;
   padding-top: 0;
   padding-bottom: 0;
-  max-width: max-content;
 }


### PR DESCRIPTION
The CSS caused the accordion titles to be squished on Firefox, this hotfix unbinds their max width.