### PR TITLE
Update timer logic to check auction status less frequently

### DIFF
--- a/packages/nouns-webapp/src/components/AuctionActivity/index.tsx
+++ b/packages/nouns-webapp/src/components/AuctionActivity/index.tsx
@@ -61,7 +61,7 @@ const AuctionActivity: React.FC<AuctionActivityProps> = (props: AuctionActivityP
     </h1>
   );
 
-  // timer logic
+  // timer logic - check auction status every 30 seconds, until five minutes remain, then check status every second
   useEffect(() => {
     if (!auction) return;
 
@@ -71,9 +71,12 @@ const AuctionActivity: React.FC<AuctionActivityProps> = (props: AuctionActivityP
       setAuctionEnded(true);
     } else {
       setAuctionEnded(false);
-      const timer = setTimeout(() => {
-        setAuctionTimer(!auctionTimer);
-      }, 1000);
+      const timer = setTimeout(
+        () => {
+          setAuctionTimer(!auctionTimer);
+        },
+        timeLeft > 300 ? 30000 : 1000,
+      );
 
       return () => {
         clearTimeout(timer);


### PR DESCRIPTION
Update timer logic to check auction status less frequently to limit component re-renders.

Initially check auction status once every 30 seconds. When less than 5 minutes remain in the auction, check the auction status every second.

** This PR addresses previous comments from @cryptoseneca and is a copy of closed PR #226 