### PR TITLE
Fixed mis-configured TrezorConnector in WalletConnectModal

### DIFF
--- a/packages/nouns-webapp/src/components/WalletConnectModal/index.tsx
+++ b/packages/nouns-webapp/src/components/WalletConnectModal/index.tsx
@@ -88,8 +88,8 @@ const WalletConnectModal: React.FC<{ onDismiss: () => void }> = props => {
           const trezor = new TrezorConnector({
             chainId: CHAIN_ID,
             url: config.app.jsonRpcUri,
-            manifestAppUrl: 'nounops+trezorconnect@protonmail.com',
-            manifestEmail: 'https://nouns.wtf',
+            manifestAppUrl: 'https://nouns.wtf',
+            manifestEmail: 'nounops+trezorconnect@protonmail.com',
           });
           activate(trezor);
         }}


### PR DESCRIPTION
email was provided in the `manifestAppUrl` field and web address was provided in the `manifestEmail` field. The commit swaps the values to their corresponding fields.