### PR TITLE
Hotfix to keep auction arrows together

### DIFF
--- a/packages/nouns-webapp/src/components/AuctionNavigation/index.tsx
+++ b/packages/nouns-webapp/src/components/AuctionNavigation/index.tsx
@@ -9,7 +9,7 @@ const AuctionNavigation: React.FC<{
 }> = props => {
   const { isFirstAuction, isLastAuction, onPrevAuctionClick, onNextAuctionClick } = props;
   return (
-    <>
+    <div>
       <button
         onClick={() => onPrevAuctionClick()}
         className={classes.leftArrow}
@@ -24,7 +24,7 @@ const AuctionNavigation: React.FC<{
       >
         →
       </button>
-    </>
+    </div>
   );
 };
 export default AuctionNavigation;


### PR DESCRIPTION
This wraps the arrows in a div so that safari renders them together rather than allowing them to flow.