### PR TITLE
Fix navigation arrow overflow

### DIFF
--- a/packages/nouns-webapp/src/components/AuctionActivity/index.tsx
+++ b/packages/nouns-webapp/src/components/AuctionActivity/index.tsx
@@ -12,6 +12,7 @@ import BidHistory from '../BidHistory';
 import { Modal } from 'react-bootstrap';
 import AuctionNavigation from '../AuctionNavigation';
 import AuctionActivityWrapper from '../AuctionActivityWrapper';
+import AuctionTitleAndNavWrapper from '../AuctionTitleAndNavWrapper';
 import AuctionActivityNounTitle from '../AuctionActivityNounTitle';
 import AuctionActivityDateHeadline from '../AuctionActivityDateHeadline';
 import BidHistoryBtn from '../BidHistoryBtn';
@@ -112,7 +113,7 @@ const AuctionActivity: React.FC<AuctionActivityProps> = (props: AuctionActivityP
             <Col lg={12}>
               <AuctionActivityDateHeadline startTime={auction.startTime} />
             </Col>
-            <Col lg={12} className={classes.colAlignCenter}>
+            <AuctionTitleAndNavWrapper>
               <AuctionActivityNounTitle nounId={auction.nounId} />
               {displayGraphDepComps && (
                 <AuctionNavigation
@@ -122,7 +123,7 @@ const AuctionActivity: React.FC<AuctionActivityProps> = (props: AuctionActivityP
                   onPrevAuctionClick={onPrevAuctionClick}
                 />
               )}
-            </Col>
+            </AuctionTitleAndNavWrapper>
           </Row>
           <Row className={classes.activityRow}>
             <Col lg={5} className={classes.currentBidCol}>

--- a/packages/nouns-webapp/src/components/AuctionNavigation/AuctionNavigation.module.css
+++ b/packages/nouns-webapp/src/components/AuctionNavigation/AuctionNavigation.module.css
@@ -1,3 +1,9 @@
+.navArrowsContainer {
+  position: absolute;
+  margin-top: 0.3rem;
+  margin-left: 12.5rem;
+}
+
 .leftArrow {
   margin-left: 1rem;
   display: inline-block;
@@ -33,5 +39,11 @@
 @media (max-width: 992px) {
   .leftArrow {
     margin-left: 1rem;
+  }
+}
+@-moz-document url-prefix() {
+  .navArrowsContainer {
+    margin-top: 0;
+    margin-bottom: 0.5rem;
   }
 }

--- a/packages/nouns-webapp/src/components/AuctionNavigation/AuctionNavigation.module.css
+++ b/packages/nouns-webapp/src/components/AuctionNavigation/AuctionNavigation.module.css
@@ -1,7 +1,7 @@
 .navArrowsContainer {
   position: absolute;
   margin-top: 0.3rem;
-  margin-left: 12.5rem;
+  margin-left: 12.35rem;
 }
 
 .leftArrow {
@@ -18,6 +18,7 @@
 }
 .rightArrow {
   margin-left: 1rem;
+  margin-left: 0.6rem;
   display: inline-block;
   width: 2rem;
   height: 2rem;

--- a/packages/nouns-webapp/src/components/AuctionNavigation/index.tsx
+++ b/packages/nouns-webapp/src/components/AuctionNavigation/index.tsx
@@ -9,7 +9,7 @@ const AuctionNavigation: React.FC<{
 }> = props => {
   const { isFirstAuction, isLastAuction, onPrevAuctionClick, onNextAuctionClick } = props;
   return (
-    <div>
+    <div className={classes.navArrowsContainer}>
       <button
         onClick={() => onPrevAuctionClick()}
         className={classes.leftArrow}

--- a/packages/nouns-webapp/src/components/AuctionTitleAndNavWrapper/AuctionTitleAndNavWrapper.module.css
+++ b/packages/nouns-webapp/src/components/AuctionTitleAndNavWrapper/AuctionTitleAndNavWrapper.module.css
@@ -1,0 +1,17 @@
+.auctionTitleAndNavContainer {
+  display: flex;
+}
+
+@media (max-width: 992px) {
+  .auctionTitleAndNavContainer h1 {
+    font-size: 2.75rem;
+  }
+}
+
+/* Fix Firefox navigation arrow alignment issues */
+@-moz-document url-prefix() {
+  .auctionTitleAndNavContainer {
+    display: flex;
+    align-items: center;
+  }
+}

--- a/packages/nouns-webapp/src/components/AuctionTitleAndNavWrapper/AuctionTitleAndNavWrapper.module.css
+++ b/packages/nouns-webapp/src/components/AuctionTitleAndNavWrapper/AuctionTitleAndNavWrapper.module.css
@@ -15,3 +15,10 @@
     align-items: center;
   }
 }
+/* Safari 7.1+ */
+/* Fix safari navigation arrow display issues */
+_::-webkit-full-page-media,
+_:future,
+:root .auctionTitleAndNavContainer button {
+  padding-bottom: 4rem;
+}

--- a/packages/nouns-webapp/src/components/AuctionTitleAndNavWrapper/index.tsx
+++ b/packages/nouns-webapp/src/components/AuctionTitleAndNavWrapper/index.tsx
@@ -1,0 +1,11 @@
+import { Col } from 'react-bootstrap';
+import classes from './AuctionTitleAndNavWrapper.module.css';
+
+const AuctionTitleAndNavWrapper: React.FC<{}> = props => {
+  return (
+    <Col lg={12} className={classes.auctionTitleAndNavContainer}>
+      {props.children}
+    </Col>
+  );
+};
+export default AuctionTitleAndNavWrapper;

--- a/packages/nouns-webapp/src/components/NounderNounContent/index.tsx
+++ b/packages/nouns-webapp/src/components/NounderNounContent/index.tsx
@@ -4,6 +4,7 @@ import AuctionActivityWrapper from '../AuctionActivityWrapper';
 import AuctionNavigation from '../AuctionNavigation';
 import AuctionActivityNounTitle from '../AuctionActivityNounTitle';
 import AuctionActivityDateHeadline from '../AuctionActivityDateHeadline';
+import AuctionTitleAndNavWrapper from '../AuctionTitleAndNavWrapper';
 import { Link } from 'react-router-dom';
 import nounContentClasses from './NounderNounContent.module.css';
 import auctionBidClasses from '../AuctionActivity/BidHistory.module.css';
@@ -35,7 +36,7 @@ const NounderNounContent: React.FC<{
           <Col lg={12}>
             <AuctionActivityDateHeadline startTime={mintTimestamp} />
           </Col>
-          <Col lg={12} className={auctionActivityClasses.colAlignCenter}>
+          <AuctionTitleAndNavWrapper>
             <AuctionActivityNounTitle nounId={nounId} />
             <AuctionNavigation
               isFirstAuction={isFirstAuction}
@@ -43,7 +44,7 @@ const NounderNounContent: React.FC<{
               onNextAuctionClick={onNextAuctionClick}
               onPrevAuctionClick={onPrevAuctionClick}
             />
-          </Col>
+          </AuctionTitleAndNavWrapper>
         </Row>
         <Row className={auctionActivityClasses.activityRow}>
           <Col lg={5} className={auctionActivityClasses.currentBidCol}>


### PR DESCRIPTION
- Fixes overflow on Safari + Chrome
- Fixes display issue on Safari where ~50% of the navigation arrow was hidden
- Sets arrow positioning as absolutes so that it does not move as Noun # width changes.

![diff](https://user-images.githubusercontent.com/85328329/140998549-61ffe92f-b3ae-47a9-b19a-0697cb56278b.png)
