### PR TITLE
Show block delegation requirement for active proposals

### DIFF
--- a/packages/nouns-webapp/src/pages/Vote/Vote.module.css
+++ b/packages/nouns-webapp/src/pages/Vote/Vote.module.css
@@ -61,3 +61,7 @@
 .voterIneligibleAlert {
   margin: 1rem 0 0 0;
 }
+
+.blockRestrictionAlert {
+  margin: 1rem 0 0 0;
+}

--- a/packages/nouns-webapp/src/pages/Vote/index.tsx
+++ b/packages/nouns-webapp/src/pages/Vote/index.tsx
@@ -83,14 +83,17 @@ const VotePage = ({
   const againstPercentage = proposal && totalVotes ? (proposal.againstCount * 100) / totalVotes : 0;
   const abstainPercentage = proposal && totalVotes ? (proposal.abstainCount * 100) / totalVotes : 0;
 
+  const proposalActive = proposal?.status === ProposalState.ACTIVE;
+
   // Only count available votes as of the proposal created block
   const availableVotes = useUserVotesAsOfBlock(proposal?.createdBlock ?? undefined);
 
   const hasVoted = useHasVotedOnProposal(proposal?.id);
 
+  const showBlockRestriction = proposalActive;
+
   // Only show voting if user has > 0 votes at proposal created block and proposal is active
-  const showVotingButtons =
-    availableVotes && !hasVoted && proposal?.status === ProposalState.ACTIVE;
+  const showVotingButtons = availableVotes && !hasVoted && proposalActive;
 
   const linkIfAddress = (content: string) => {
     if (utils.isAddress(content)) {
@@ -255,15 +258,25 @@ const VotePage = ({
             ''
           )}
         </div>
-        {proposal && proposal.status === ProposalState.ACTIVE && !showVotingButtons && (
-          <Alert
-            variant={hasVoted ? 'success' : 'secondary'}
-            className={classes.voterIneligibleAlert}
-          >
-            {hasVoted
-              ? 'Thank you for your vote!'
-              : `Only NOUN votes that were self delegated or delegated to another address before block ${proposal.createdBlock} are eligible for voting.`}
-          </Alert>
+        {proposal && proposalActive && (
+          <>
+            {showBlockRestriction && !hasVoted && (
+              <Alert
+              variant="secondary"
+                className={classes.blockRestrictionAlert}
+              >
+                  Only NOUN votes that were self delegated or delegated to another address before block {proposal.createdBlock} are eligible for voting.
+              </Alert>
+            )}
+            {hasVoted && (
+              <Alert
+                variant='success'
+                className={classes.voterIneligibleAlert}
+              >
+                  Thank you for your vote!
+              </Alert>
+            )}
+          </>
         )}
         {showVotingButtons ? (
           <Row>


### PR DESCRIPTION
This PR adjusts the proposal page so that it shows the block number delegation warning[0] if the proposal is active and the connected account has not yet voted. Previously it only rendered if the connected account had 0 eligible Nouns. For cases where users had an additional Noun delegated after the cut off, they could see a low eligible Noun count.

[0]: eg: `Only NOUN votes that were self delegated or delegated to another address before block 55 are eligible for voting.`

[See discussion](https://discord.com/channels/849745721544146955/854365616093659166/913828283483836476)