### PR TITLE
Use custom render method to add Providers to App following doc

### DIFF
--- a/packages/nouns-webapp/package.json
+++ b/packages/nouns-webapp/package.json
@@ -79,5 +79,13 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "jest": {
+    "moduleNameMapper": {
+      "\\.(css|less|sass|scss)$": "identity-obj-proxy"
+    },
+    "transformIgnorePatterns": [
+      "../../node_modules/(?!(react-markdown|remark-breaks)/)"
+    ]
   }
 }

--- a/packages/nouns-webapp/src/App.test.tsx
+++ b/packages/nouns-webapp/src/App.test.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen } from './test-utils';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders Nouns elements', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const nounElements = screen.getAllByText(/noun/i);
+  nounElements.map(element => expect(element).toBeInTheDocument());
 });

--- a/packages/nouns-webapp/src/index.tsx
+++ b/packages/nouns-webapp/src/index.tsx
@@ -1,77 +1,37 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import ReactDOM from 'react-dom';
 import './index.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
 import { ChainId, DAppProvider } from '@usedapp/core';
 import { Web3ReactProvider } from '@web3-react/core';
-import { Web3Provider } from '@ethersproject/providers';
-import account from './state/slices/account';
-import application from './state/slices/application';
-import logs from './state/slices/logs';
-import auction, {
+import { Web3Provider, WebSocketProvider } from '@ethersproject/providers';
+import {
+  appendBid,
   reduxSafeAuction,
-  reduxSafeNewAuction,
   reduxSafeBid,
+  reduxSafeNewAuction,
   setActiveAuction,
   setAuctionExtended,
   setAuctionSettled,
   setFullAuction,
 } from './state/slices/auction';
-import onDisplayAuction, {
-  setLastAuctionNounId,
-  setOnDisplayAuctionNounId,
-} from './state/slices/onDisplayAuction';
+import { setLastAuctionNounId, setOnDisplayAuctionNounId } from './state/slices/onDisplayAuction';
 import { ApolloProvider, useQuery } from '@apollo/client';
 import { clientFactory, latestAuctionsQuery } from './wrappers/subgraph';
-import { useEffect } from 'react';
-import pastAuctions, { addPastAuctions } from './state/slices/pastAuctions';
+import { addPastAuctions } from './state/slices/pastAuctions';
 import LogsUpdater from './state/updaters/logs';
 import config, { CHAIN_ID, createNetworkHttpUrl } from './config';
-import { WebSocketProvider } from '@ethersproject/providers';
 import { BigNumber, BigNumberish } from 'ethers';
 import { NounsAuctionHouseFactory } from '@nouns/sdk';
 import dotenv from 'dotenv';
 import { useAppDispatch, useAppSelector } from './hooks';
-import { appendBid } from './state/slices/auction';
-import { ConnectedRouter, connectRouter } from 'connected-react-router';
-import { createBrowserHistory, History } from 'history';
-import { applyMiddleware, createStore, combineReducers, PreloadedState } from 'redux';
-import { routerMiddleware } from 'connected-react-router';
+import { ConnectedRouter, push } from 'connected-react-router';
 import { Provider } from 'react-redux';
-import { composeWithDevTools } from 'redux-devtools-extension';
 import { nounPath } from './utils/history';
-import { push } from 'connected-react-router';
+import configureStore, { history } from './store';
 
 dotenv.config();
-
-export const history = createBrowserHistory();
-
-const createRootReducer = (history: History) =>
-  combineReducers({
-    router: connectRouter(history),
-    account,
-    application,
-    auction,
-    logs,
-    pastAuctions,
-    onDisplayAuction,
-  });
-
-export default function configureStore(preloadedState: PreloadedState<any>) {
-  const store = createStore(
-    createRootReducer(history), // root reducer with router state
-    preloadedState,
-    composeWithDevTools(
-      applyMiddleware(
-        routerMiddleware(history), // for dispatching history actions
-        // ... other middlewares ...
-      ),
-    ),
-  );
-
-  return store;
-}
 
 const store = configureStore({});
 

--- a/packages/nouns-webapp/src/store.ts
+++ b/packages/nouns-webapp/src/store.ts
@@ -1,0 +1,36 @@
+import { createBrowserHistory, History } from 'history';
+import { applyMiddleware, combineReducers, createStore, PreloadedState } from 'redux';
+import { connectRouter, routerMiddleware } from 'connected-react-router';
+import account from './state/slices/account';
+import application from './state/slices/application';
+import auction from './state/slices/auction';
+import logs from './state/slices/logs';
+import pastAuctions from './state/slices/pastAuctions';
+import onDisplayAuction from './state/slices/onDisplayAuction';
+import { composeWithDevTools } from 'redux-devtools-extension';
+
+export const history = createBrowserHistory();
+
+const createRootReducer = (history: History) =>
+  combineReducers({
+    router: connectRouter(history),
+    account,
+    application,
+    auction,
+    logs,
+    pastAuctions,
+    onDisplayAuction,
+  });
+
+export default function configureStore(preloadedState: PreloadedState<any>) {
+  return createStore(
+    createRootReducer(history), // root reducer with router state
+    preloadedState,
+    composeWithDevTools(
+      applyMiddleware(
+        routerMiddleware(history), // for dispatching history actions
+        // ... other middlewares ...
+      ),
+    ),
+  );
+}

--- a/packages/nouns-webapp/src/test-utils.tsx
+++ b/packages/nouns-webapp/src/test-utils.tsx
@@ -1,0 +1,25 @@
+// see https://testing-library.com/docs/react-testing-library/setup/#custom-render
+// and use:
+// - import { render, fireEvent } from '@testing-library/react';
+// + import { render, fireEvent } from '../test-utils';
+import React, { FC, ReactElement } from 'react';
+import { render, RenderOptions } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { ConnectedRouter } from 'connected-react-router';
+import configureStore, { history } from './store';
+
+const AllTheProviders: FC = ({ children }) => {
+  return (
+    <Provider store={configureStore({})}>
+      <ConnectedRouter history={history}>
+        <React.StrictMode>{children}</React.StrictMode>
+      </ConnectedRouter>
+    </Provider>
+  );
+};
+
+const customRender = (ui: ReactElement, options?: Omit<RenderOptions, 'wrapper'>) =>
+  render(ui, { wrapper: AllTheProviders, ...options });
+
+export * from '@testing-library/react';
+export { customRender as render };


### PR DESCRIPTION
Currently, running `yarn test` into the `nouns-webapp` raises an error because of the missing store `Provider`.

Following the ad-hoc documentation found [here](https://testing-library.com/docs/react-testing-library/setup/#custom-render) I have updated the existing default test so that it passes and further test can be written.