### PR TITLE
Add support for abstain votes in Noun profile

### DIFF
--- a/packages/nouns-webapp/src/assets/icons/Abstain.svg
+++ b/packages/nouns-webapp/src/assets/icons/Abstain.svg
@@ -1,0 +1,4 @@
+<svg width="36" height="36" viewBox="0 0 36 36" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="36" height="36" rx="18" fill="#4965F0" fill-opacity="0.1"/>
+<circle cx="18" cy="18" r="6.5" stroke="#8C8D91" stroke-width="3"/>
+</svg>

--- a/packages/nouns-webapp/src/components/ProfileActivityFeed/index.tsx
+++ b/packages/nouns-webapp/src/components/ProfileActivityFeed/index.tsx
@@ -17,9 +17,10 @@ interface ProposalInfo {
   id: number;
 }
 
-interface NounVoteHistory {
+export interface NounVoteHistory {
   proposal: ProposalInfo;
   support: boolean;
+  supportDetailed: number;
 }
 
 const ProfileActivityFeed: React.FC<ProfileActivityFeedProps> = props => {
@@ -34,14 +35,13 @@ const ProfileActivityFeed: React.FC<ProfileActivityFeedProps> = props => {
     return <div>Failed to fetch noun activity history</div>;
   }
 
-  const proposalsVotedOn = data.noun.votes
+  const nounVotes: { [key: string]: NounVoteHistory } = data.noun.votes
     .slice(0)
-    .map((h: NounVoteHistory, i: number) => h.proposal.id);
+    .reduce((acc: any, h: NounVoteHistory, i: number) => {
+      acc[h.proposal.id] = h;
+      return acc;
+    }, {});
 
-  const supportedProposals = data.noun.votes
-    .slice(0)
-    .filter((h: NounVoteHistory, i: number) => h.support)
-    .map((h: NounVoteHistory, i: number) => h.proposal.id);
 
   const latestProposalId = proposals?.length;
 
@@ -59,11 +59,11 @@ const ProfileActivityFeed: React.FC<ProfileActivityFeedProps> = props => {
                 .slice(0)
                 .reverse()
                 .map((p: Proposal, i: number) => {
+                  const vote = p.id ? nounVotes[p.id] : undefined;
                   return (
                     <NounProfileVoteRow
                       proposal={p}
-                      nounVoted={proposalsVotedOn.includes(p.id)}
-                      nounSupported={supportedProposals.includes(p.id)}
+                      vote={vote}
                       latestProposalId={latestProposalId}
                       nounId={nounId}
                       key={i}

--- a/packages/nouns-webapp/src/utils/vote.ts
+++ b/packages/nouns-webapp/src/utils/vote.ts
@@ -1,0 +1,5 @@
+export enum Vote {
+	SUPPORT = 0,
+	FOR = 1,
+	ABSTAIN = 2
+}

--- a/packages/nouns-webapp/src/wrappers/subgraph.ts
+++ b/packages/nouns-webapp/src/wrappers/subgraph.ts
@@ -166,6 +166,7 @@ export const nounVotingHistoryQuery = (nounId: number) => gql`
 			id
 		}
 		support
+		supportDetailed
 		}
 	}
 }


### PR DESCRIPTION
This adds an Abstain icon to the Noun profile page so that it doesn't render the same as a vote against. The icon is just a slapped together circle which could be replaced by just swapping out `Abstain.svg` later. It also refactors the vote row props just pass in the entire vote.

![abstainrow](https://user-images.githubusercontent.com/85326879/144356843-4a8f5ec0-e0c8-4254-a7ba-53431c9f1d57.png)