### PR TITLE
Add end time to auction and in time to proposals

### DIFF
--- a/packages/nouns-webapp/src/App.tsx
+++ b/packages/nouns-webapp/src/App.tsx
@@ -21,10 +21,13 @@ import Playground from './pages/Playground';
 import { CHAIN_ID } from './config';
 import VerifyPage from './pages/Verify';
 import ProfilePage from './pages/Profile';
+import relativeTime from 'dayjs/plugin/relativeTime'
+import dayjs from 'dayjs';
 
 function App() {
   const { account, chainId } = useEthers();
   const dispatch = useAppDispatch();
+  dayjs.extend(relativeTime)
 
   useEffect(() => {
     // Local account array updated

--- a/packages/nouns-webapp/src/components/AuctionTimer/AuctionTimer.module.css
+++ b/packages/nouns-webapp/src/components/AuctionTimer/AuctionTimer.module.css
@@ -18,3 +18,12 @@
 .timeSubtitle {
   font-size: medium;
 }
+
+.clockSection {
+  margin-right: 0rem;
+  min-width: 250px
+}
+
+.auctionTimerSection {
+  cursor: pointer;
+}

--- a/packages/nouns-webapp/src/components/AuctionTimer/index.tsx
+++ b/packages/nouns-webapp/src/components/AuctionTimer/index.tsx
@@ -13,10 +13,12 @@ const AuctionTimer: React.FC<{
   const { auction, auctionEnded } = props;
 
   const [auctionTimer, setAuctionTimer] = useState(0);
+  const [timerToggle, setTimerToggle] = useState(true);
   const auctionTimerRef = useRef(auctionTimer); // to access within setTimeout
   auctionTimerRef.current = auctionTimer;
 
   const timerDuration = dayjs.duration(auctionTimerRef.current, 's');
+  const endTime = dayjs().add(auctionTimerRef.current, "s").local()
 
   // timer logic
   useEffect(() => {
@@ -37,7 +39,7 @@ const AuctionTimer: React.FC<{
     }
   }, [auction, auctionTimer]);
 
-  const auctionContent = auctionEnded ? 'Auction ended' : 'Ends in';
+  const auctionContent = auctionEnded ? 'Auction ended' : (timerToggle ? 'Ends in' : `Ends on ${endTime.format('MMM Do')} at`);
 
   const flooredMinutes = Math.floor(timerDuration.minutes());
   const flooredSeconds = Math.floor(timerDuration.seconds());
@@ -45,29 +47,39 @@ const AuctionTimer: React.FC<{
   if (!auction) return null;
 
   return (
-    <>
-      <h4 className={classes.title}>{auctionContent}</h4>
-      <h2 className={classes.timerWrapper}>
-        <div className={classes.timerSection}>
-          <span>
-            {`${Math.floor(timerDuration.hours())}`}
-            <span className={classes.small}>h</span>
-          </span>
-        </div>
-        <div className={classes.timerSection}>
-          <span>
-            {`${flooredMinutes}`}
-            <span className={classes.small}>m</span>
-          </span>
-        </div>
-        <div className={classes.timerSection}>
-          <span>
-            {`${flooredSeconds}`}
-            <span className={classes.small}>s</span>
-          </span>
-        </div>
-      </h2>
-    </>
+    <div onClick={() => setTimerToggle(!timerToggle)} className={classes.auctionTimerSection}>
+          <h4 className={classes.title}>{auctionContent}</h4>
+      {timerToggle ? (
+          <h2 className={classes.timerWrapper}>
+            <div className={classes.timerSection}>
+              <span>
+                {`${Math.floor(timerDuration.hours())}`}
+                <span className={classes.small}>h</span>
+              </span>
+            </div>
+            <div className={classes.timerSection}>
+              <span>
+                {`${flooredMinutes}`}
+                <span className={classes.small}>m</span>
+              </span>
+            </div>
+            <div className={classes.timerSection}>
+              <span>
+                {`${flooredSeconds}`}
+                <span className={classes.small}>s</span>
+              </span>
+            </div>
+          </h2>
+      ) : (
+          <h2 className={classes.timerWrapper}>
+            <div className={classes.clockSection}>
+              <span>
+              {endTime.format('h:mm:ss a')}
+              </span>
+            </div>
+          </h2>
+      )}
+    </div>
   );
 };
 

--- a/packages/nouns-webapp/src/pages/Vote/index.tsx
+++ b/packages/nouns-webapp/src/pages/Vote/index.tsx
@@ -230,7 +230,7 @@ const VotePage = ({
         </div>
         <div>
           {startDate && startDate.isBefore(now) ? null : proposal ? (
-            <span>Voting starts approximately {startDate?.format('MMMM D, YYYY h:mm A z')}</span>
+            <span>Voting starts approximately {startDate?.format('MMMM D, YYYY h:mm A z')} {startDate && `(${(startDate as any).fromNow()})`} </span>
           ) : (
             ''
           )}
@@ -246,7 +246,7 @@ const VotePage = ({
             </>
           ) : proposal ? (
             <>
-              <div>Voting ends approximately {endDate?.format('MMMM D, YYYY h:mm A z')}</div>
+              <div>Voting ends approximately {endDate?.format('MMMM D, YYYY h:mm A z')} {endDate && `(${(endDate as any).fromNow()})`} </div>
               {proposal?.quorumVotes !== undefined && (
                 <div>A total of {proposal.quorumVotes} votes are required to reach quorum</div>
               )}


### PR DESCRIPTION
This adds the ability to click on the auction timer to have it display the ending time for the local user.

![endsat](https://user-images.githubusercontent.com/85326879/144359928-04906d77-5111-41f7-98aa-775431c79c5e.png)

It also adds an `in XX t` helper to the proposal times to help users understand when things happen.

![votein](https://user-images.githubusercontent.com/85326879/144359984-e936bdf7-148e-4766-9320-804df1fd5c33.png)


