### PR TITLE
Add discourse link to nav

### DIFF
--- a/packages/nouns-webapp/src/components/NavBar/index.tsx
+++ b/packages/nouns-webapp/src/components/NavBar/index.tsx
@@ -119,6 +119,14 @@ const NavBar = () => {
             >
               DOCS
             </Nav.Link>
+            <Nav.Link 
+              href={externalURL(ExternalURL.discourse)}
+              className={classes.nounsNavLink}
+              target="_blank"
+              rel="noreferrer"
+            >
+              DISCOURSE
+            </Nav.Link>
             <Nav.Link as={Link} to="/playground" className={classes.nounsNavLink}>
               PLAYGROUND
             </Nav.Link>


### PR DESCRIPTION
Per Noun22's request, I have added a link to discourse to the main nav of nouns.wtf