### PR TITLE
Include Lido balance in Navbar treasury details and link to Etherscan token holdings page

### DIFF
--- a/packages/nouns-contracts/hardhat.config.ts
+++ b/packages/nouns-contracts/hardhat.config.ts
@@ -35,7 +35,7 @@ const config: HardhatUserConfig = {
         : [process.env.WALLET_PRIVATE_KEY!].filter(Boolean),
     },
     hardhat: {
-      initialBaseFeePerGas: 0, 
+      initialBaseFeePerGas: 0,
     },
   },
   etherscan: {

--- a/packages/nouns-webapp/src/App.tsx
+++ b/packages/nouns-webapp/src/App.tsx
@@ -21,13 +21,13 @@ import Playground from './pages/Playground';
 import { CHAIN_ID } from './config';
 import VerifyPage from './pages/Verify';
 import ProfilePage from './pages/Profile';
-import relativeTime from 'dayjs/plugin/relativeTime'
+import relativeTime from 'dayjs/plugin/relativeTime';
 import dayjs from 'dayjs';
 
 function App() {
   const { account, chainId } = useEthers();
   const dispatch = useAppDispatch();
-  dayjs.extend(relativeTime)
+  dayjs.extend(relativeTime);
 
   useEffect(() => {
     // Local account array updated

--- a/packages/nouns-webapp/src/components/AuctionTimer/AuctionTimer.module.css
+++ b/packages/nouns-webapp/src/components/AuctionTimer/AuctionTimer.module.css
@@ -21,7 +21,7 @@
 
 .clockSection {
   margin-right: 0rem;
-  min-width: 250px
+  min-width: 250px;
 }
 
 .auctionTimerSection {

--- a/packages/nouns-webapp/src/components/AuctionTimer/index.tsx
+++ b/packages/nouns-webapp/src/components/AuctionTimer/index.tsx
@@ -18,7 +18,7 @@ const AuctionTimer: React.FC<{
   auctionTimerRef.current = auctionTimer;
 
   const timerDuration = dayjs.duration(auctionTimerRef.current, 's');
-  const endTime = dayjs().add(auctionTimerRef.current, "s").local()
+  const endTime = dayjs().add(auctionTimerRef.current, 's').local();
 
   // timer logic
   useEffect(() => {
@@ -39,7 +39,11 @@ const AuctionTimer: React.FC<{
     }
   }, [auction, auctionTimer]);
 
-  const auctionContent = auctionEnded ? 'Auction ended' : (timerToggle ? 'Ends in' : `Ends on ${endTime.format('MMM Do')} at`);
+  const auctionContent = auctionEnded
+    ? 'Auction ended'
+    : timerToggle
+    ? 'Ends in'
+    : `Ends on ${endTime.format('MMM Do')} at`;
 
   const flooredMinutes = Math.floor(timerDuration.minutes());
   const flooredSeconds = Math.floor(timerDuration.seconds());
@@ -48,36 +52,34 @@ const AuctionTimer: React.FC<{
 
   return (
     <div onClick={() => setTimerToggle(!timerToggle)} className={classes.auctionTimerSection}>
-          <h4 className={classes.title}>{auctionContent}</h4>
+      <h4 className={classes.title}>{auctionContent}</h4>
       {timerToggle ? (
-          <h2 className={classes.timerWrapper}>
-            <div className={classes.timerSection}>
-              <span>
-                {`${Math.floor(timerDuration.hours())}`}
-                <span className={classes.small}>h</span>
-              </span>
-            </div>
-            <div className={classes.timerSection}>
-              <span>
-                {`${flooredMinutes}`}
-                <span className={classes.small}>m</span>
-              </span>
-            </div>
-            <div className={classes.timerSection}>
-              <span>
-                {`${flooredSeconds}`}
-                <span className={classes.small}>s</span>
-              </span>
-            </div>
-          </h2>
+        <h2 className={classes.timerWrapper}>
+          <div className={classes.timerSection}>
+            <span>
+              {`${Math.floor(timerDuration.hours())}`}
+              <span className={classes.small}>h</span>
+            </span>
+          </div>
+          <div className={classes.timerSection}>
+            <span>
+              {`${flooredMinutes}`}
+              <span className={classes.small}>m</span>
+            </span>
+          </div>
+          <div className={classes.timerSection}>
+            <span>
+              {`${flooredSeconds}`}
+              <span className={classes.small}>s</span>
+            </span>
+          </div>
+        </h2>
       ) : (
-          <h2 className={classes.timerWrapper}>
-            <div className={classes.clockSection}>
-              <span>
-              {endTime.format('h:mm:ss a')}
-              </span>
-            </div>
-          </h2>
+        <h2 className={classes.timerWrapper}>
+          <div className={classes.clockSection}>
+            <span>{endTime.format('h:mm:ss a')}</span>
+          </div>
+        </h2>
       )}
     </div>
   );

--- a/packages/nouns-webapp/src/components/NavBar/index.tsx
+++ b/packages/nouns-webapp/src/components/NavBar/index.tsx
@@ -14,6 +14,7 @@ import config, { CHAIN_ID } from '../../config';
 import { utils } from 'ethers';
 import { buildEtherscanAddressLink } from '../../utils/etherscan';
 import { ExternalURL, externalURL } from '../../utils/externalURL';
+import useLidoBalance from '../../hooks/useLidoBalance';
 
 const NavBar = () => {
   const activeAccount = useAppSelector(state => state.account.activeAccount);
@@ -21,8 +22,9 @@ const NavBar = () => {
 
   const stateBgColor = useAppSelector(state => state.application.stateBackgroundColor);
   const history = useHistory();
-  const treasuryBalance = useEtherBalance(config.addresses.nounsDaoExecutor);
-  const daoEtherscanLink = buildEtherscanAddressLink(config.addresses.nounsDaoExecutor);
+  const ethBalance = useEtherBalance(config.addresses.nounsDaoExecutor);
+  const lidoBalanceAsETH = useLidoBalance();
+  const treasuryBalance = ethBalance && lidoBalanceAsETH && ethBalance.add(lidoBalanceAsETH);
 
   const [showConnectModal, setShowConnectModal] = useState(false);
 

--- a/packages/nouns-webapp/src/components/NavBar/index.tsx
+++ b/packages/nouns-webapp/src/components/NavBar/index.tsx
@@ -12,7 +12,7 @@ import testnetNoun from '../../assets/testnet-noun.png';
 import clsx from 'clsx';
 import config, { CHAIN_ID } from '../../config';
 import { utils } from 'ethers';
-import { buildEtherscanAddressLink } from '../../utils/etherscan';
+import { buildEtherscanHoldingsLink } from '../../utils/etherscan';
 import { ExternalURL, externalURL } from '../../utils/externalURL';
 import useLidoBalance from '../../hooks/useLidoBalance';
 
@@ -25,6 +25,7 @@ const NavBar = () => {
   const ethBalance = useEtherBalance(config.addresses.nounsDaoExecutor);
   const lidoBalanceAsETH = useLidoBalance();
   const treasuryBalance = ethBalance && lidoBalanceAsETH && ethBalance.add(lidoBalanceAsETH);
+  const daoEtherscanLink = buildEtherscanHoldingsLink(config.addresses.nounsDaoExecutor);
 
   const [showConnectModal, setShowConnectModal] = useState(false);
 

--- a/packages/nouns-webapp/src/components/NavBar/index.tsx
+++ b/packages/nouns-webapp/src/components/NavBar/index.tsx
@@ -122,7 +122,7 @@ const NavBar = () => {
             >
               DOCS
             </Nav.Link>
-            <Nav.Link 
+            <Nav.Link
               href={externalURL(ExternalURL.discourse)}
               className={classes.nounsNavLink}
               target="_blank"

--- a/packages/nouns-webapp/src/components/NounProfileVoteRow/index.tsx
+++ b/packages/nouns-webapp/src/components/NounProfileVoteRow/index.tsx
@@ -24,10 +24,7 @@ interface NounProfileVoteRowProps {
   vote?: NounVoteHistory;
 }
 
-const selectIconForNounVoteActivityRow = (
-  proposal: Proposal,
-  vote?: NounVoteHistory,
-) => {
+const selectIconForNounVoteActivityRow = (proposal: Proposal, vote?: NounVoteHistory) => {
   if (!vote) {
     if (proposal.status === ProposalState.PENDING || proposal.status === ProposalState.ACTIVE) {
       return <Image src={_PendingVoteIcon} className={classes.voteIcon} />;
@@ -60,7 +57,6 @@ const selectVotingInfoText = (proposal: Proposal, vote?: NounVoteHistory) => {
       default:
         return 'Abstained on';
     }
-
   } else {
     return 'Voted aginst';
   }
@@ -136,9 +132,7 @@ const NounProfileVoteRow: React.FC<NounProfileVoteRowProps> = props => {
 
   return (
     <tr onClick={proposalOnClickHandler} className={classes.voteInfoRow}>
-      <td className={classes.voteIcon}>
-        {selectIconForNounVoteActivityRow(proposal, vote)}
-      </td>
+      <td className={classes.voteIcon}>{selectIconForNounVoteActivityRow(proposal, vote)}</td>
       <td>
         <div className={classes.voteInfoContainer}>
           {selectVotingInfoText(proposal, vote)}

--- a/packages/nouns-webapp/src/components/ProfileActivityFeed/index.tsx
+++ b/packages/nouns-webapp/src/components/ProfileActivityFeed/index.tsx
@@ -42,7 +42,6 @@ const ProfileActivityFeed: React.FC<ProfileActivityFeedProps> = props => {
       return acc;
     }, {});
 
-
   const latestProposalId = proposals?.length;
 
   return (

--- a/packages/nouns-webapp/src/config.ts
+++ b/packages/nouns-webapp/src/config.ts
@@ -1,5 +1,14 @@
-import { ContractAddresses, getContractAddressesForChainOrThrow } from '@nouns/sdk';
+import {
+  ContractAddresses as NounsContractAddresses,
+  getContractAddressesForChainOrThrow,
+} from '@nouns/sdk';
 import { ChainId } from '@usedapp/core';
+
+interface ExternalContractAddresses {
+  lidoToken: string | undefined;
+}
+
+export type ContractAddresses = NounsContractAddresses & ExternalContractAddresses;
 
 interface AppConfig {
   jsonRpcUri: string;
@@ -47,12 +56,24 @@ const app: Record<SupportedChains, AppConfig> = {
   },
 };
 
-const getAddresses = () => {
+const externalAddresses: Record<SupportedChains, ExternalContractAddresses> = {
+  [ChainId.Rinkeby]: {
+    lidoToken: '0xF4242f9d78DB7218Ad72Ee3aE14469DBDE8731eD',
+  },
+  [ChainId.Mainnet]: {
+    lidoToken: '0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84',
+  },
+  [ChainId.Hardhat]: {
+    lidoToken: undefined,
+  },
+};
+
+const getAddresses = (): ContractAddresses => {
+  let nounsAddresses = {} as NounsContractAddresses;
   try {
-    return getContractAddressesForChainOrThrow(CHAIN_ID);
-  } catch {
-    return {} as ContractAddresses;
-  }
+    nounsAddresses = getContractAddressesForChainOrThrow(CHAIN_ID);
+  } catch {}
+  return { ...nounsAddresses, ...externalAddresses[CHAIN_ID] };
 };
 
 const config = {

--- a/packages/nouns-webapp/src/hooks/useLidoBalance.ts
+++ b/packages/nouns-webapp/src/hooks/useLidoBalance.ts
@@ -1,0 +1,31 @@
+import { useMemo, useEffect, useState } from 'react';
+import { Contract } from '@ethersproject/contracts';
+import { useEthers } from '@usedapp/core';
+import { utils, BigNumber } from 'ethers';
+import config from '../config';
+import ERC20 from '../libs/abi/ERC20.json';
+
+const {
+  addresses: { lidoToken, nounsDaoExecutor },
+} = config;
+
+const abi = new utils.Interface(ERC20);
+
+function useLidoBalance(): BigNumber | undefined {
+  const { library } = useEthers();
+
+  const [balance, setBalance] = useState(undefined);
+
+  const contract = useMemo(() => {
+    return library && lidoToken && new Contract(lidoToken, abi, library);
+  }, [library, lidoToken]);
+
+  useEffect(() => {
+    if (!contract || !nounsDaoExecutor) return;
+    contract.balanceOf(nounsDaoExecutor).then(setBalance);
+  }, [contract, nounsDaoExecutor]);
+
+  return balance;
+}
+
+export default useLidoBalance;

--- a/packages/nouns-webapp/src/hooks/useLidoBalance.ts
+++ b/packages/nouns-webapp/src/hooks/useLidoBalance.ts
@@ -18,12 +18,12 @@ function useLidoBalance(): BigNumber | undefined {
 
   const contract = useMemo(() => {
     return library && lidoToken && new Contract(lidoToken, abi, library);
-  }, [library, lidoToken]);
+  }, [library]);
 
   useEffect(() => {
     if (!contract || !nounsDaoExecutor) return;
     contract.balanceOf(nounsDaoExecutor).then(setBalance);
-  }, [contract, nounsDaoExecutor]);
+  }, [contract]);
 
   return balance;
 }

--- a/packages/nouns-webapp/src/hooks/useLidoBalance.ts
+++ b/packages/nouns-webapp/src/hooks/useLidoBalance.ts
@@ -5,25 +5,24 @@ import { utils, BigNumber } from 'ethers';
 import config from '../config';
 import ERC20 from '../libs/abi/ERC20.json';
 
-const {
-  addresses: { lidoToken, nounsDaoExecutor },
-} = config;
+const { addresses } = config;
 
-const abi = new utils.Interface(ERC20);
+const erc20Interface = new utils.Interface(ERC20);
 
 function useLidoBalance(): BigNumber | undefined {
   const { library } = useEthers();
 
   const [balance, setBalance] = useState(undefined);
 
-  const contract = useMemo(() => {
-    return library && lidoToken && new Contract(lidoToken, abi, library);
+  const lidoContract = useMemo((): Contract | undefined => {
+    if (!library || !addresses.lidoToken) return;
+    return new Contract(addresses.lidoToken, erc20Interface, library);
   }, [library]);
 
   useEffect(() => {
-    if (!contract || !nounsDaoExecutor) return;
-    contract.balanceOf(nounsDaoExecutor).then(setBalance);
-  }, [contract]);
+    if (!lidoContract || !addresses.nounsDaoExecutor) return;
+    lidoContract.balanceOf(addresses.nounsDaoExecutor).then(setBalance);
+  }, [lidoContract]);
 
   return balance;
 }

--- a/packages/nouns-webapp/src/libs/abi/ERC20.json
+++ b/packages/nouns-webapp/src/libs/abi/ERC20.json
@@ -1,0 +1,11 @@
+[
+  {
+    "constant": true,
+    "inputs": [{ "name": "_account", "type": "address" }],
+    "name": "balanceOf",
+    "outputs": [{ "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/packages/nouns-webapp/src/pages/Vote/index.tsx
+++ b/packages/nouns-webapp/src/pages/Vote/index.tsx
@@ -233,7 +233,10 @@ const VotePage = ({
         </div>
         <div>
           {startDate && startDate.isBefore(now) ? null : proposal ? (
-            <span>Voting starts approximately {startDate?.format('MMMM D, YYYY h:mm A z')} {startDate && `(${(startDate as any).fromNow()})`} </span>
+            <span>
+              Voting starts approximately {startDate?.format('MMMM D, YYYY h:mm A z')}{' '}
+              {startDate && `(${(startDate as any).fromNow()})`}{' '}
+            </span>
           ) : (
             ''
           )}
@@ -249,7 +252,10 @@ const VotePage = ({
             </>
           ) : proposal ? (
             <>
-              <div>Voting ends approximately {endDate?.format('MMMM D, YYYY h:mm A z')} {endDate && `(${(endDate as any).fromNow()})`} </div>
+              <div>
+                Voting ends approximately {endDate?.format('MMMM D, YYYY h:mm A z')}{' '}
+                {endDate && `(${(endDate as any).fromNow()})`}{' '}
+              </div>
               {proposal?.quorumVotes !== undefined && (
                 <div>A total of {proposal.quorumVotes} votes are required to reach quorum</div>
               )}
@@ -261,19 +267,14 @@ const VotePage = ({
         {proposal && proposalActive && (
           <>
             {showBlockRestriction && !hasVoted && (
-              <Alert
-              variant="secondary"
-                className={classes.blockRestrictionAlert}
-              >
-                  Only NOUN votes that were self delegated or delegated to another address before block {proposal.createdBlock} are eligible for voting.
+              <Alert variant="secondary" className={classes.blockRestrictionAlert}>
+                Only NOUN votes that were self delegated or delegated to another address before
+                block {proposal.createdBlock} are eligible for voting.
               </Alert>
             )}
             {hasVoted && (
-              <Alert
-                variant='success'
-                className={classes.voterIneligibleAlert}
-              >
-                  Thank you for your vote!
+              <Alert variant="success" className={classes.voterIneligibleAlert}>
+                Thank you for your vote!
               </Alert>
             )}
           </>

--- a/packages/nouns-webapp/src/utils/etherscan.ts
+++ b/packages/nouns-webapp/src/utils/etherscan.ts
@@ -22,6 +22,11 @@ export const buildEtherscanAddressLink = (address: string): string => {
   return new URL(path, BASE_URL).toString();
 };
 
+export const buildEtherscanHoldingsLink = (address: string): string => {
+  const path = `tokenholdings?a=${address}`;
+  return new URL(path, BASE_URL).toString();
+};
+
 const getApiBaseURL = (network: ChainId) => {
   switch (network) {
     case ChainId.Rinkeby:

--- a/packages/nouns-webapp/src/utils/vote.ts
+++ b/packages/nouns-webapp/src/utils/vote.ts
@@ -1,5 +1,5 @@
 export enum Vote {
-	SUPPORT = 0,
-	FOR = 1,
-	ABSTAIN = 2
+  SUPPORT = 0,
+  FOR = 1,
+  ABSTAIN = 2,
 }


### PR DESCRIPTION
This adds NounsExecutor's Lido stETH balance to its ETH balance in the Navbar. It also links the treasury to Etherscan's token holdings page.

Resolves #305  