### PR TITLE
Proposal Creation Timestamp

### DIFF
--- a/packages/nouns-subgraph/schema.graphql
+++ b/packages/nouns-subgraph/schema.graphql
@@ -160,6 +160,9 @@ type Proposal @entity {
   "Call data for the change"
   calldatas: [Bytes!]
 
+  "The proposal creation timestamp"
+  createdTimestamp: BigInt!
+
   "Block number from where the voting starts"
   startBlock: BigInt!
 

--- a/packages/nouns-subgraph/src/nouns-dao.ts
+++ b/packages/nouns-subgraph/src/nouns-dao.ts
@@ -46,6 +46,7 @@ export function handleProposalCreatedWithRequirements(
   proposal.values = event.params.values;
   proposal.signatures = event.params.signatures;
   proposal.calldatas = event.params.calldatas;
+  proposal.createdTimestamp = event.block.timestamp;
   proposal.startBlock = event.params.startBlock;
   proposal.endBlock = event.params.endBlock;
   proposal.proposalThreshold = event.params.proposalThreshold;


### PR DESCRIPTION
Add the proposal creation timestamp to the `Proposal` subgraph entity for use in the frontend.