### PR TITLE
Add leading slash back in

### DIFF
--- a/packages/nouns-webapp/src/components/Proposals/index.tsx
+++ b/packages/nouns-webapp/src/components/Proposals/index.tsx
@@ -28,7 +28,7 @@ const Proposals = ({ proposals }: { proposals: Proposal[] }) => {
               <Button
                 className={classes.proposalLink}
                 variant="dark"
-                onClick={() => history.push(`vote/${p.id}`)}
+                onClick={() => history.push(`/vote/${p.id}`)}
                 key={i}
               >
                 <span>


### PR DESCRIPTION
This adds the leading slash back in to the proposal onClick event. If users navigated to the page `/vote/` they would end up getting routed to `/vote/vote/N`. This reverses the change included in #276 and is confirmed as not structural to that PR.