### PR TITLE
Display Value in All Proposal Function Calls

### DIFF
--- a/packages/nouns-webapp/src/pages/Governance/index.tsx
+++ b/packages/nouns-webapp/src/pages/Governance/index.tsx
@@ -7,20 +7,17 @@ import classes from './Governance.module.css';
 const GovernancePage = () => {
   const { data: proposals } = useAllProposals();
   const threshold = useProposalThreshold();
-  const nounsCopy =
-    threshold !== undefined && `${threshold + 1} ${threshold === 0 ? 'Noun' : 'Nouns'}`;
+  const nounsRequired = threshold !== undefined ? threshold + 1 : '...';
+  const nounThresholdCopy = `${nounsRequired} ${threshold === 0 ? 'Noun' : 'Nouns'}`;
 
   return (
     <Section fullWidth={true}>
       <Col lg={{ span: 8, offset: 2 }}>
         <h1 className={classes.heading}>Nouns DAO Governance</h1>
-        {threshold !== undefined && (
-          <p className={classes.subheading}>
-            {`Nouns govern NounsDAO. Nouns can vote on proposals or delegate their vote to a third
-            party. A minimum of ${nounsCopy} is required to submit
-            proposals.`}
-          </p>
-        )}
+        <p className={classes.subheading}>
+          Nouns govern NounsDAO. Nouns can vote on proposals or delegate their vote to a third
+          party. A minimum of {nounThresholdCopy} is required to submit proposals.
+        </p>
         <Proposals proposals={proposals} />
       </Col>
     </Section>

--- a/packages/nouns-webapp/src/pages/Vote/Vote.module.css
+++ b/packages/nouns-webapp/src/pages/Vote/Vote.module.css
@@ -3,8 +3,6 @@
 }
 
 .proposal {
-  border-radius: 5px;
-  padding: 1rem 2.5rem;
   margin-top: 1em;
   background-color: white;
 }

--- a/packages/nouns-webapp/src/pages/Vote/index.tsx
+++ b/packages/nouns-webapp/src/pages/Vote/index.tsx
@@ -21,7 +21,7 @@ import utc from 'dayjs/plugin/utc';
 import timezone from 'dayjs/plugin/timezone';
 import advanced from 'dayjs/plugin/advancedFormat';
 import VoteModal from '../../components/VoteModal';
-import { useCallback, useEffect, useState } from 'react';
+import { Fragment, useCallback, useEffect, useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkBreaks from 'remark-breaks';
 import { utils } from 'ethers';
@@ -394,14 +394,14 @@ const VotePage = ({
                     <br />
                     {d.callData.split(',').map((content, i) => {
                       return (
-                        <>
+                        <Fragment key={i}>
                           <span key={i}>
                             &emsp;
                             {linkIfAddress(content)}
                             {d.callData.split(',').length - 1 === i ? '' : ','}
                           </span>
                           <br />
-                        </>
+                        </Fragment>
                       );
                     })}
                     )

--- a/packages/nouns-webapp/src/pages/Vote/index.tsx
+++ b/packages/nouns-webapp/src/pages/Vote/index.tsx
@@ -385,22 +385,30 @@ const VotePage = ({
         <Row>
           <Col className={classes.section}>
             <h5>Proposed Transactions</h5>
-            {proposal?.details?.map((d, i) => {
-              return (
-                <p key={i} className="m-0">
-                  {i + 1}: {linkIfAddress(d.target)}.{d.functionSig}(
-                  {d.callData.split(',').map((content, i) => {
-                    return (
-                      <span key={i}>
-                        {linkIfAddress(content)}
-                        {d.callData.split(',').length - 1 === i ? '' : ','}
-                      </span>
-                    );
-                  })}
-                  )
-                </p>
-              );
-            })}
+            <ol>
+              {proposal?.details?.map((d, i) => {
+                return (
+                  <li key={i} className="m-0">
+                    {linkIfAddress(d.target)}.{d.functionSig}
+                    {d.value}(
+                    <br />
+                    {d.callData.split(',').map((content, i) => {
+                      return (
+                        <>
+                          <span key={i}>
+                            &emsp;
+                            {linkIfAddress(content)}
+                            {d.callData.split(',').length - 1 === i ? '' : ','}
+                          </span>
+                          <br />
+                        </>
+                      );
+                    })}
+                    )
+                  </li>
+                );
+              })}
+            </ol>
           </Col>
         </Row>
         <Row>

--- a/packages/nouns-webapp/src/wrappers/nounsDao.ts
+++ b/packages/nouns-webapp/src/wrappers/nounsDao.ts
@@ -44,6 +44,7 @@ interface ProposalCallResult {
 
 interface ProposalDetail {
   target: string;
+  value: string;
   functionSig: string;
   callData: string;
 }
@@ -169,7 +170,8 @@ const useFormattedProposalCreatedLogs = () => {
           return {
             target,
             functionSig: name,
-            callData: decoded.join(', '),
+            callData: decoded.join(),
+            value: value.gt(0) ? `{ value: ${utils.formatEther(value)} ETH }` : '',
           };
         }),
       };


### PR DESCRIPTION
Display proposal function call values on all functions where the value is non-zero. Previously, the value was only displayed if there was no additional calldata.

e.g
<img width="616" alt="example" src="https://user-images.githubusercontent.com/85371573/147631000-4fd01e8d-b216-4086-8a77-42f97ea35784.png">