### PR TITLE
Default to FOMO Nouns for Settlement 

### DIFF
--- a/packages/nouns-webapp/src/components/Bid/Bid.module.css
+++ b/packages/nouns-webapp/src/components/Bid/Bid.module.css
@@ -96,4 +96,18 @@
   .customPlaceholder {
     left: 44%;
   }
+  .emergencySettleWrapper {
+    text-align: center;
+  }
+}
+
+.emergencySettleButton {
+  color: var(--brand-dark-red);
+  background-color: transparent;
+  border: none;
+  cursor: pointer;
+  text-decoration: underline;
+  display: inline;
+  margin: 0;
+  padding: 0;
 }

--- a/packages/nouns-webapp/src/components/Bid/index.tsx
+++ b/packages/nouns-webapp/src/components/Bid/index.tsx
@@ -226,6 +226,16 @@ const Bid: React.FC<{
   const isDisabled =
     placeBidState.status === 'Mining' || settleAuctionState.status === 'Mining' || !activeAccount;
 
+  const fomoNounsBtnOnClickHandler = () => {
+    // Open Fomo Nouns in a new tab
+    window.open(
+      'https://fomonouns.wtf',
+      '_blank' 
+    )?.focus();
+  };
+
+  const isWalletConnected = activeAccount !== undefined;
+
   return (
     <>
       {!auctionEnded && (
@@ -247,13 +257,35 @@ const Bid: React.FC<{
             <span className={classes.customPlaceholder}>ETH</span>
           </>
         )}
-        <Button
-          className={auctionEnded ? classes.bidBtnAuctionEnded : classes.bidBtn}
-          onClick={auctionEnded ? settleAuctionHandler : placeBidHandler}
-          disabled={isDisabled}
-        >
-          {bidButtonContent.loading ? <Spinner animation="border" /> : bidButtonContent.content}
-        </Button>
+        {
+          !auctionEnded ? (
+              <Button
+                className={auctionEnded ? classes.bidBtnAuctionEnded : classes.bidBtn}
+                onClick={auctionEnded ? settleAuctionHandler : placeBidHandler}
+                disabled={isDisabled}
+              >
+                {bidButtonContent.loading ? <Spinner animation="border" /> : bidButtonContent.content}
+              </Button>
+          ) 
+          : (
+            <>
+              <Button
+                className={classes.bidBtnAuctionEnded}
+                onClick={fomoNounsBtnOnClickHandler}
+              >
+                Vote for the next Noun ⌐◨-◨
+            </Button>
+            {/* Only show force settle button if wallet connected */}
+            {isWalletConnected &&  (<p className={classes.emergencySettleWrapper}>
+              <button onClick={settleAuctionHandler} className={
+                classes.emergencySettleButton
+              }>
+                Pay to settle manually
+              </button>
+            </p>)}
+            </>
+          )
+        }
       </InputGroup>
     </>
   );

--- a/packages/nouns-webapp/src/components/Bid/index.tsx
+++ b/packages/nouns-webapp/src/components/Bid/index.tsx
@@ -273,7 +273,7 @@ const Bid: React.FC<{
                 className={classes.bidBtnAuctionEnded}
                 onClick={fomoNounsBtnOnClickHandler}
               >
-                Vote for the next Noun ⌐◨-◨
+                Vote for the next Noun ⌐◧-◧
             </Button>
             {/* Only show force settle button if wallet connected */}
             {isWalletConnected &&  (<p className={classes.emergencySettleWrapper}>


### PR DESCRIPTION
# TLDR

- Replaces `Settle Auction` button with `Help mint the next Noun` button
- This button links (in a new tab) to fomonouns.wtf
- Adds copy under `Help mint the next Noun` button to allow for force settlement (legacy settlement mechanic) 

# Screenshots 

## Mobile
<img width="361" alt="Screen Shot 2022-01-06 at 1 52 39 PM" src="https://user-images.githubusercontent.com/12565062/148435875-ba05e244-a1d5-4f7b-b6f1-2b0a75d2bb54.png">

## Desktop
<img width="582" alt="Screen Shot 2022-01-06 at 1 52 19 PM" src="https://user-images.githubusercontent.com/12565062/148435891-0e6234a8-fea0-4635-893f-9486b3fbc5b7.png">

# Testing Done
1. Confirmed that when `auctionEnded` is `true` then new experience is shown, otherwise not
2. Confirmed that clicking `Help mint the next Noun` button links (in a new tab) to fomonouns.wtf
3. Confirmed that clicking the emergency settlement link brings up the settlement modal (because there is no active auction right now, it correctly displays a modal telling me there is no active auction) 