### PR TITLE
Add link to Fomo Nouns on active auction 

### DIFF
--- a/packages/nouns-webapp/src/components/AuctionActivity/AuctionActivity.module.css
+++ b/packages/nouns-webapp/src/components/AuctionActivity/AuctionActivity.module.css
@@ -56,6 +56,9 @@ h4 {
   .auctionTimerCol {
     padding-left: 15px;
   }
+  .fomoNounsLink {
+    text-align: center;
+  }
 }
 
 /* Fix Firefox navigation arrow alignment issues */
@@ -64,4 +67,19 @@ h4 {
     display: flex;
     align-items: center;
   }
+}
+.fomoNounsLink {
+  color: #8c8d92;
+}
+
+.fomoNounsLink a,
+.fomoNounsLink:hover a .fomoNounsLink:active a {
+  color: #8c8d92;
+  padding-left: 0.5rem;
+}
+
+.fomoNounsLink:hover,
+.fomoNounsLink:hover a {
+  text-decoration: underline;
+  color: #8c8d9275;
 }

--- a/packages/nouns-webapp/src/components/AuctionActivity/index.tsx
+++ b/packages/nouns-webapp/src/components/AuctionActivity/index.tsx
@@ -150,7 +150,7 @@ const AuctionActivity: React.FC<AuctionActivityProps> = (props: AuctionActivityP
                 <Bid auction={auction} auctionEnded={auctionEnded} />
               </Col>
             </Row>
-            {!auctionEnded ? (
+            {!auctionEnded && (
               <Row className={classes.activityRow}>
                 <Col lg={12} className={classes.fomoNounsLink}>
                   <FontAwesomeIcon icon={faInfoCircle} />
@@ -159,8 +159,6 @@ const AuctionActivity: React.FC<AuctionActivityProps> = (props: AuctionActivityP
                   </a>
                 </Col>
               </Row>
-            ) : (
-              <></>
             )}
           </>
         )}

--- a/packages/nouns-webapp/src/components/AuctionActivity/index.tsx
+++ b/packages/nouns-webapp/src/components/AuctionActivity/index.tsx
@@ -19,6 +19,8 @@ import BidHistoryBtn from '../BidHistoryBtn';
 import StandaloneNoun from '../StandaloneNoun';
 import config from '../../config';
 import { buildEtherscanAddressLink } from '../../utils/etherscan';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faInfoCircle } from '@fortawesome/free-solid-svg-icons';
 
 const openEtherscanBidHistory = () => {
   const url = buildEtherscanAddressLink(config.addresses.nounsAuctionHouseProxy);
@@ -142,11 +144,25 @@ const AuctionActivity: React.FC<AuctionActivityProps> = (props: AuctionActivityP
           </Row>
         </div>
         {isLastAuction && (
-          <Row className={classes.activityRow}>
-            <Col lg={12}>
-              <Bid auction={auction} auctionEnded={auctionEnded} />
-            </Col>
-          </Row>
+          <>
+            <Row className={classes.activityRow}>
+              <Col lg={12}>
+                <Bid auction={auction} auctionEnded={auctionEnded} />
+              </Col>
+            </Row>
+            {!auctionEnded ? (
+              <Row className={classes.activityRow}>
+                <Col lg={12} className={classes.fomoNounsLink}>
+                  <FontAwesomeIcon icon={faInfoCircle} />
+                  <a href={'https://fomonouns.wtf'} target={'_blank'} rel="noreferrer">
+                    Help mint the next Noun
+                  </a>
+                </Col>
+              </Row>
+            ) : (
+              <></>
+            )}
+          </>
         )}
         <Row className={classes.activityRow}>
           <Col lg={12}>


### PR DESCRIPTION
# TLDR
This PR adds a link to `fomonouns.wtf` for active auctions. This link disappears when an auction is ready to be settled or when a user pages back to previous auctions. 