### PR TITLE
Use block timestamp, rather than block number, in voting alert

### DIFF
--- a/packages/nouns-webapp/src/hooks/useBlockTimestamp.ts
+++ b/packages/nouns-webapp/src/hooks/useBlockTimestamp.ts
@@ -1,0 +1,19 @@
+import { useEffect, useState } from 'react';
+import { useEthers } from '@usedapp/core';
+
+export function useBlockTimestamp(blockno: number | undefined): number | undefined {
+  const { library } = useEthers();
+  const [blockTimestamp, setBlockTimestamp] = useState<number | undefined>();
+
+  async function updateBlockTimestamp() {
+    if (!blockno) return;
+    const blockData = await library?.getBlock(blockno);
+    setBlockTimestamp(blockData?.timestamp || undefined);
+  }
+
+  useEffect(() => {
+    updateBlockTimestamp();
+  }, []);
+
+  return blockTimestamp;
+}

--- a/packages/nouns-webapp/src/pages/Vote/index.tsx
+++ b/packages/nouns-webapp/src/pages/Vote/index.tsx
@@ -26,6 +26,7 @@ import ReactMarkdown from 'react-markdown';
 import remarkBreaks from 'remark-breaks';
 import { utils } from 'ethers';
 import { useAppDispatch } from '../../hooks';
+import { useBlockTimestamp } from '../../hooks/useBlockTimestamp';
 
 dayjs.extend(utc);
 dayjs.extend(timezone);
@@ -54,6 +55,7 @@ const VotePage = ({
   const { castVote, castVoteState } = useCastVote();
   const { queueProposal, queueProposalState } = useQueueProposal();
   const { executeProposal, executeProposalState } = useExecuteProposal();
+  const proposalCreationTimestamp = useBlockTimestamp(proposal?.createdBlock);
 
   // Get and format date from data
   const timestamp = Date.now();
@@ -268,8 +270,8 @@ const VotePage = ({
           <>
             {showBlockRestriction && !hasVoted && (
               <Alert variant="secondary" className={classes.blockRestrictionAlert}>
-                Only NOUN votes that were self delegated or delegated to another address before
-                block {proposal.createdBlock} are eligible for voting.
+                Only Nouns in your wallet or delegated to you before{' '}
+                {dayjs(proposalCreationTimestamp).format('MMMM D, YYYY h:mm A z')} can vote.
               </Alert>
             )}
             {hasVoted && (


### PR DESCRIPTION
The method of retrieving the timestamp is definitely opinionated. I've seen the etherscan API being used but though this was a better approach so it worked in the dev environment. If you'd rather retrieve the timestamp in a different method, let me know I'm happy to fix.

![Screen Shot 2022-02-26 at 12 49 14 PM](https://user-images.githubusercontent.com/99738501/155853808-7065d545-d6f4-47a0-ab2a-9db654a25893.png)
Resolves https://github.com/nounsDAO/nouns-monorepo/issues/197