### PR TITLE
Nouns full historical list

### DIFF
--- a/packages/nouns-webapp/src/App.tsx
+++ b/packages/nouns-webapp/src/App.tsx
@@ -18,6 +18,7 @@ import VotePage from './pages/Vote';
 import NoundersPage from './pages/Nounders';
 import NotFoundPage from './pages/NotFound';
 import Playground from './pages/Playground';
+import HistoryPage from './pages/HistoricalNouns';
 import { CHAIN_ID } from './config';
 import VerifyPage from './pages/Verify';
 import relativeTime from 'dayjs/plugin/relativeTime';
@@ -61,6 +62,7 @@ function App() {
           <Route exact path="/vote" component={GovernancePage} />
           <Route exact path="/vote/:id" component={VotePage} />
           <Route exact path="/playground" component={Playground} />
+          <Route exact path="/history" component={HistoryPage} />
           <Route component={NotFoundPage} />
         </Switch>
         <Footer />

--- a/packages/nouns-webapp/src/components/NavBar/index.tsx
+++ b/packages/nouns-webapp/src/components/NavBar/index.tsx
@@ -13,7 +13,7 @@ import { ExternalURL, externalURL } from '../../utils/externalURL';
 import useLidoBalance from '../../hooks/useLidoBalance';
 import NavBarButton, { NavBarButtonStyle } from '../NavBarButton';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faBookOpen } from '@fortawesome/free-solid-svg-icons';
+import { faBookOpen, faHistory } from '@fortawesome/free-solid-svg-icons';
 import { faUsers } from '@fortawesome/free-solid-svg-icons';
 import { faComments } from '@fortawesome/free-solid-svg-icons';
 import { faPlay } from '@fortawesome/free-solid-svg-icons';
@@ -112,6 +112,13 @@ const NavBar = () => {
               <NavBarButton
                 buttonText={'Playground'}
                 buttonIcon={<FontAwesomeIcon icon={faPlay} />}
+                buttonStyle={nonWalletButtonStyle}
+              />
+            </Nav.Link>
+            <Nav.Link as={Link} to="/history" className={classes.nounsNavLink}>
+              <NavBarButton
+                buttonText={'Noun History'}
+                buttonIcon={<FontAwesomeIcon icon={faHistory} />}
                 buttonStyle={nonWalletButtonStyle}
               />
             </Nav.Link>

--- a/packages/nouns-webapp/src/components/Noun/NounSeed/NounSeed.module.css
+++ b/packages/nouns-webapp/src/components/Noun/NounSeed/NounSeed.module.css
@@ -1,0 +1,13 @@
+.boldText {
+    font-family: 'PT Root UI';
+    font-weight: bold;
+}
+
+p {
+    padding-top: 1rem;
+}
+
+.seedDataText{
+    font-family: 'PT Root UI';
+    font-weight: 500;
+}

--- a/packages/nouns-webapp/src/components/Noun/NounSeed/NounSeed.module.css
+++ b/packages/nouns-webapp/src/components/Noun/NounSeed/NounSeed.module.css
@@ -1,13 +1,13 @@
 .boldText {
-    font-family: 'PT Root UI';
-    font-weight: bold;
+  font-family: 'PT Root UI';
+  font-weight: bold;
 }
 
 p {
-    padding-top: 1rem;
+  padding-top: 1rem;
 }
 
-.seedDataText{
-    font-family: 'PT Root UI';
-    font-weight: 500;
+.seedDataText {
+  font-family: 'PT Root UI';
+  font-weight: 500;
 }

--- a/packages/nouns-webapp/src/components/Noun/NounSeed/index.tsx
+++ b/packages/nouns-webapp/src/components/Noun/NounSeed/index.tsx
@@ -16,7 +16,20 @@ interface NounSeedProps {
   traitRarity: Map<string, Tuple<number, number>>;
 }
 
+interface NounSeedEntry {
+  entry: [string, number];
+}
 const NounSeed = (props: NounSeedProps) => {
+  const TraitNameEntry = (props: NounSeedEntry) => {
+    const entry: [string, number] = props.entry;
+    return (
+      <>
+        <span className={classes.boldText}>{capitalizeFirstLetter(entry[0])}: </span>
+        {parseTraitName(traitNames[traitTitles.indexOf(entry[0])][entry[1]])}{' '}
+      </>
+    );
+  };
+
   return (
     <>
       {Object.entries(props.seed)
@@ -24,28 +37,31 @@ const NounSeed = (props: NounSeedProps) => {
           if (traitTitles.indexOf(entry[0]) < 0) return null;
           return (
             <Col className={classes.seedDataText}>
-              <OverlayTrigger
-                trigger={['focus', 'hover']}
-                placement="top"
-                overlay={
-                  <Tooltip>
-                    <i>
-                      Trait Rarity: {(props.traitRarity.get(entry[0])![1] * 100).toFixed(2)}%,{' '}
-                      {props.traitRarity.get(entry[0])![0]} total{' '}
-                    </i>
-                  </Tooltip>
-                }
-              >
-                <span {...props}>
-                  <span className={classes.boldText}>{capitalizeFirstLetter(entry[0])}: </span>
-                  {parseTraitName(traitNames[traitTitles.indexOf(entry[0])][entry[1]])}{' '}
-                  {props.traitRarity.get(entry[0])![0] === 1 ? (
-                    <FontAwesomeIcon icon={faStar} />
-                  ) : (
-                    ''
-                  )}
-                </span>
-              </OverlayTrigger>
+              {props.traitRarity ? (
+                <OverlayTrigger
+                  trigger={['focus', 'hover']}
+                  placement="top"
+                  overlay={
+                    <Tooltip>
+                      <i>
+                        Trait Rarity: {(props.traitRarity.get(entry[0])![1] * 100).toFixed(2)}%,{' '}
+                        {props.traitRarity.get(entry[0])![0]} total{' '}
+                      </i>
+                    </Tooltip>
+                  }
+                >
+                  <span {...props}>
+                    <TraitNameEntry entry={entry} />
+                    {props.traitRarity.get(entry[0])![0] === 1 ? (
+                      <FontAwesomeIcon icon={faStar} />
+                    ) : (
+                      ''
+                    )}
+                  </span>
+                </OverlayTrigger>
+              ) : (
+                <TraitNameEntry entry={entry} />
+              )}
             </Col>
           );
         })

--- a/packages/nouns-webapp/src/components/Noun/NounSeed/index.tsx
+++ b/packages/nouns-webapp/src/components/Noun/NounSeed/index.tsx
@@ -1,0 +1,57 @@
+import { faStar } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { Tuple } from 'ramda';
+import { Col, OverlayTrigger, Tooltip } from 'react-bootstrap';
+import {
+  capitalizeFirstLetter,
+  parseTraitName,
+  traitNames,
+  traitTitles,
+} from '../../../pages/Playground';
+import { INounSeed } from '../../../wrappers/nounToken';
+import classes from './NounSeed.module.css';
+
+interface NounSeedProps {
+  seed: INounSeed;
+  traitRarity: Map<string, Tuple<number, number>>;
+}
+
+const NounSeed = (props: NounSeedProps) => {
+  return (
+    <>
+      {Object.entries(props.seed)
+        .map((entry: [string, number]) => {
+          if (traitTitles.indexOf(entry[0]) < 0) return null;
+          return (
+            <Col className={classes.seedDataText}>
+              <OverlayTrigger
+                trigger={['focus', 'hover']}
+                placement="top"
+                overlay={
+                  <Tooltip>
+                    <i>
+                      Trait Rarity: {(props.traitRarity.get(entry[0])![1] * 100).toFixed(2)}%,{' '}
+                      {props.traitRarity.get(entry[0])![0]} total{' '}
+                    </i>
+                  </Tooltip>
+                }
+              >
+                <span {...props}>
+                  <span className={classes.boldText}>{capitalizeFirstLetter(entry[0])}: </span>
+                  {parseTraitName(traitNames[traitTitles.indexOf(entry[0])][entry[1]])}{' '}
+                  {props.traitRarity.get(entry[0])![0] === 1 ? (
+                    <FontAwesomeIcon icon={faStar} />
+                  ) : (
+                    ''
+                  )}
+                </span>
+              </OverlayTrigger>
+            </Col>
+          );
+        })
+        .filter(a => !!a)}
+    </>
+  );
+};
+
+export default NounSeed;

--- a/packages/nouns-webapp/src/components/StandaloneNoun/StandaloneNoun.module.css
+++ b/packages/nouns-webapp/src/components/StandaloneNoun/StandaloneNoun.module.css
@@ -1,3 +1,9 @@
 .clickableNoun {
   cursor: pointer;
 }
+
+.headerRow h1 {
+  color: #434958;
+  font-size: 28px;
+  font-family: 'Londrina Solid';
+}

--- a/packages/nouns-webapp/src/components/StandaloneNoun/index.tsx
+++ b/packages/nouns-webapp/src/components/StandaloneNoun/index.tsx
@@ -7,6 +7,9 @@ import { Link } from 'react-router-dom';
 import classes from './StandaloneNoun.module.css';
 import { useDispatch } from 'react-redux';
 import { setOnDisplayAuctionNounId } from '../../state/slices/onDisplayAuction';
+import NounSeed from '../Noun/NounSeed';
+import { Col, Container } from 'react-bootstrap';
+import { Tuple } from 'ramda';
 
 interface StandaloneNounProps {
   nounId: EthersBN;
@@ -16,6 +19,13 @@ interface StandaloneNounWithSeedProps {
   nounId: EthersBN;
   onLoadSeed?: (seed: INounSeed) => void;
   shouldLinkToProfile: boolean;
+}
+
+interface StandaloneNounWithPreloadedSeedProps {
+  nounId: EthersBN;
+  shouldLinkToProfile: boolean;
+  seed: INounSeed;
+  traitRarity?: Map<string, Tuple<number, number>>;
 }
 
 const getNoun = (nounId: string | EthersBN, seed: INounSeed) => {
@@ -85,4 +95,43 @@ export const StandaloneNounWithSeed: React.FC<StandaloneNounWithSeedProps> = (
   return shouldLinkToProfile ? nounWithLink : noun;
 };
 
+export const StandaloneNounWithPreloadedSeed: React.FC<StandaloneNounWithPreloadedSeedProps> = (
+  props: StandaloneNounWithPreloadedSeedProps,
+) => {
+  const { nounId, shouldLinkToProfile, seed } = props;
+
+  const dispatch = useDispatch();
+
+  if (!seed || !nounId) return <Noun imgPath="" alt="Noun" />;
+
+  const onClickHandler = () => {
+    dispatch(setOnDisplayAuctionNounId(nounId.toNumber()));
+  };
+
+  const { image, description } = getNoun(nounId, seed);
+
+  const noun = <Noun imgPath={image} alt={description} />;
+  const seedComponent = <NounSeed seed={seed} traitRarity={props.traitRarity!} />;
+  const nounWithLink = (
+    <Link
+      to={'/noun/' + nounId.toString()}
+      className={classes.clickableNoun}
+      onClick={onClickHandler}
+    >
+      {noun}
+    </Link>
+  );
+
+  const nounDisplayWithoutSeed = shouldLinkToProfile ? nounWithLink : noun;
+  const nounWithSeed = (
+    <Container>
+      <Col className={ classes.headerRow }>
+        <h1>Noun {props.nounId.toString()}</h1>
+      </Col>
+      {nounDisplayWithoutSeed}
+      {seedComponent}
+    </Container>
+  );
+  return nounWithSeed;
+};
 export default StandaloneNoun;

--- a/packages/nouns-webapp/src/components/StandaloneNoun/index.tsx
+++ b/packages/nouns-webapp/src/components/StandaloneNoun/index.tsx
@@ -125,7 +125,7 @@ export const StandaloneNounWithPreloadedSeed: React.FC<StandaloneNounWithPreload
   const nounDisplayWithoutSeed = shouldLinkToProfile ? nounWithLink : noun;
   const nounWithSeed = (
     <Container>
-      <Col className={ classes.headerRow }>
+      <Col className={classes.headerRow}>
         <h1>Noun {props.nounId.toString()}</h1>
       </Col>
       {nounDisplayWithoutSeed}

--- a/packages/nouns-webapp/src/components/Winner/Winner.module.css
+++ b/packages/nouns-webapp/src/components/Winner/Winner.module.css
@@ -98,6 +98,6 @@
   }
 
   .youCopy {
-    padding-right: .25rem;
+    padding-right: 0.25rem;
   }
 }

--- a/packages/nouns-webapp/src/pages/HistoricalNouns/HistoricalNouns.module.css
+++ b/packages/nouns-webapp/src/pages/HistoricalNouns/HistoricalNouns.module.css
@@ -1,76 +1,73 @@
 .nounWrapper {
-    width: 100%;
+  width: 100%;
 }
 
 .nounContentCol {
-    display: flex;
+  display: flex;
 }
 
-
 @media (max-width: 992px) {
-    .nounWrapper {
-        width: 70%;
-        margin-left: 15%;
-        margin-right: 15%;
-    }
-
+  .nounWrapper {
+    width: 70%;
+    margin-left: 15%;
+    margin-right: 15%;
+  }
 }
 
 @media (max-width: 568px) {
+  .nounWrapper {
+    width: 80%;
+    margin-left: 10%;
+    margin-right: 10%;
+    margin-top: 2rem;
+  }
 
-    .nounWrapper {
-        width: 80%;
-        margin-left: 10%;
-        margin-right: 10%;
-        margin-top: 2rem;
-    }
-
-    .nounContentCol {
-        padding: 0rem;
-    }
+  .nounContentCol {
+    padding: 0rem;
+  }
 }
 .heading {
-    display: inline-block;
-    font-weight: bold;
-    font-size: 3rem;
+  display: inline-block;
+  font-weight: bold;
+  font-size: 3rem;
 }
 
 .headerRow span {
-    color: #8c8d92;
-    font-size: 24px;
-    font-family: 'Londrina Solid';
+  color: #8c8d92;
+  font-size: 24px;
+  font-family: 'Londrina Solid';
 }
 
 .headerRow h1 {
-    color: #14161b;
-    font-size: 56px;
-    font-family: 'Londrina Solid';
+  color: #14161b;
+  font-size: 56px;
+  font-family: 'Londrina Solid';
 }
 
 .subheading {
-    color: var(--brand-dark-green);
-    font-family: 'PT Root UI';
-    font-weight: 500;
-    font-size: 1.2rem;
+  color: var(--brand-dark-green);
+  font-family: 'PT Root UI';
+  font-weight: 500;
+  font-size: 1.2rem;
 }
 
 .boldText {
-    font-family: 'PT Root UI';
-    font-weight: bold;
+  font-family: 'PT Root UI';
+  font-weight: bold;
 }
 
 p {
-    padding-top: 1rem;
+  padding-top: 1rem;
 }
 
 @media (max-width: 992px) {
-    .section {
-        margin-left: 0.5rem;
-        margin-right: 0.5rem;
-    }
+  .section {
+    margin-left: 0.5rem;
+    margin-right: 0.5rem;
+  }
 }
 
 .wrapper {
-    margin-left: auto;
-    margin-right: auto;
+  margin-left: auto;
+  margin-right: auto;
 }

--- a/packages/nouns-webapp/src/pages/HistoricalNouns/HistoricalNouns.module.css
+++ b/packages/nouns-webapp/src/pages/HistoricalNouns/HistoricalNouns.module.css
@@ -1,0 +1,76 @@
+.nounWrapper {
+    width: 100%;
+}
+
+.nounContentCol {
+    display: flex;
+}
+
+
+@media (max-width: 992px) {
+    .nounWrapper {
+        width: 70%;
+        margin-left: 15%;
+        margin-right: 15%;
+    }
+
+}
+
+@media (max-width: 568px) {
+
+    .nounWrapper {
+        width: 80%;
+        margin-left: 10%;
+        margin-right: 10%;
+        margin-top: 2rem;
+    }
+
+    .nounContentCol {
+        padding: 0rem;
+    }
+}
+.heading {
+    display: inline-block;
+    font-weight: bold;
+    font-size: 3rem;
+}
+
+.headerRow span {
+    color: #8c8d92;
+    font-size: 24px;
+    font-family: 'Londrina Solid';
+}
+
+.headerRow h1 {
+    color: #14161b;
+    font-size: 56px;
+    font-family: 'Londrina Solid';
+}
+
+.subheading {
+    color: var(--brand-dark-green);
+    font-family: 'PT Root UI';
+    font-weight: 500;
+    font-size: 1.2rem;
+}
+
+.boldText {
+    font-family: 'PT Root UI';
+    font-weight: bold;
+}
+
+p {
+    padding-top: 1rem;
+}
+
+@media (max-width: 992px) {
+    .section {
+        margin-left: 0.5rem;
+        margin-right: 0.5rem;
+    }
+}
+
+.wrapper {
+    margin-left: auto;
+    margin-right: auto;
+}

--- a/packages/nouns-webapp/src/pages/HistoricalNouns/index.tsx
+++ b/packages/nouns-webapp/src/pages/HistoricalNouns/index.tsx
@@ -1,0 +1,103 @@
+import { useQuery } from '@apollo/client';
+import { BigNumber } from 'ethers';
+import { Tuple } from 'ramda';
+import { useState } from 'react';
+import { Button, Col, Container, Row } from 'react-bootstrap';
+import { StandaloneNounWithPreloadedSeed } from '../../components/StandaloneNoun';
+import { INounSeed } from '../../wrappers/nounToken';
+import { allNounQuery } from '../../wrappers/subgraph';
+import classes from './HistoricalNouns.module.css';
+
+interface Noun {
+  id: string;
+  seed: INounSeed;
+  traitRarity?: Map<string, Tuple<number, number>>;
+}
+const LIMIT = 69;
+const HistoryPage = () => {
+  const { loading, error, data, fetchMore } = useQuery(allNounQuery(), {
+    variables: {
+      offset: 0,
+      limit: LIMIT,
+    },
+  });
+
+  const [isLoadingMore, setIsLoadingMore] = useState<boolean>(false);
+
+  const nounContent = (noun: Noun) => (
+    <div className={classes.nounWrapper}>
+      <StandaloneNounWithPreloadedSeed
+        nounId={BigNumber.from(noun.id)}
+        shouldLinkToProfile={true}
+        seed={noun.seed}
+        traitRarity={noun.traitRarity}
+      />
+    </div>
+  );
+
+  const loadMore = async () => {
+    setIsLoadingMore(true);
+    await fetchMore({
+      variables: { offset: nounsWithRarity.length, limit: LIMIT },
+      updateQuery: (prev, { fetchMoreResult }) => {
+        const mergedAuctions = prev.auctions.concat(fetchMoreResult.auctions);
+        const newData = {
+          ...prev,
+          auctions: mergedAuctions,
+        };
+        return newData;
+      },
+    });
+    setIsLoadingMore(false);
+  };
+
+  const appendRarityToNoun = (nouns: Noun[]) => {
+    return nouns.map(noun => {
+      const rarity = new Map<string, any>();
+      const keys = Object.keys(noun.seed).filter(k => !k.includes('typename'));
+      keys.map(key => {
+        const duplicates = nouns.filter(
+          noun2 => (noun2.seed as any)[key] === (noun.seed as any)[key],
+        ).length;
+        return rarity.set(key, [duplicates, duplicates / nouns.length]);
+      });
+      return {
+        ...noun,
+        traitRarity: rarity,
+      } as Noun;
+    });
+  };
+
+  if (loading) {
+    return <Container>Loading nouns... </Container>;
+  } else if (error) {
+    return <Container>Failed to load nouns</Container>;
+  }
+  const nouns = data.auctions.map((a: any) => a.noun);
+  const nounsWithRarity = appendRarityToNoun(nouns);
+  return (
+    <Container>
+      <Row className={classes.headerRow}>
+        <span>History</span>
+        <h1>Historical Nouns</h1>
+      </Row>
+      <p className={classes.subheading}>
+        Meet the collection of nouns that have already been minted!
+      </p>
+      <Row lg={4} xs={1}>
+        {nounsWithRarity.map((noun: Noun) => {
+          return <Col>{nounContent(noun)}</Col>;
+        })}
+        {isLoadingMore ? (
+          'loading...'
+        ) : (
+          <Button variant="light" onClick={() => loadMore()}>
+            Load More
+          </Button>
+        )}
+      </Row>
+    </Container>
+  );
+};
+
+export default HistoryPage;

--- a/packages/nouns-webapp/src/pages/HistoricalNouns/index.tsx
+++ b/packages/nouns-webapp/src/pages/HistoricalNouns/index.tsx
@@ -13,7 +13,8 @@ interface Noun {
   seed: INounSeed;
   traitRarity?: Map<string, Tuple<number, number>>;
 }
-const LIMIT = 1000;
+const LIMIT = 69;
+
 const HistoryPage = () => {
   const { loading, error, data, fetchMore } = useQuery(allNounQuery(), {
     variables: {
@@ -24,6 +25,7 @@ const HistoryPage = () => {
 
   const [isLoadingMore, setIsLoadingMore] = useState<boolean>(false);
 
+  const shouldShowRarity = process.env.REACT_APP_SHOW_RARITY ?? false;
   const nounContent = (noun: Noun) => (
     <div className={classes.nounWrapper}>
       <StandaloneNounWithPreloadedSeed
@@ -39,7 +41,7 @@ const HistoryPage = () => {
     setIsLoadingMore(true);
     await fetchMore({
       variables: { offset: nounsWithRarity.length, limit: LIMIT },
-      updateQuery: (prev, { fetchMoreResult }) => {
+      updateQuery: (prev: any, { fetchMoreResult }: any) => {
         const mergedAuctions = prev.auctions.concat(fetchMoreResult.auctions);
         const newData = {
           ...prev,
@@ -54,6 +56,7 @@ const HistoryPage = () => {
   // assumes you have copmlete view of the nouns
   // doesnt work with pagination after len(nouns) > LIMIT
   // better to handle this in the subgraph probably
+  // disabled for this reason 
   const appendRarityToNoun = (nouns: Noun[]) => {
     return nouns.map(noun => {
       const rarity = new Map<string, any>();
@@ -81,7 +84,7 @@ const HistoryPage = () => {
     return <Container>Failed to load nouns</Container>;
   }
   const nouns = data.auctions.map((a: any) => a.noun);
-  const nounsWithRarity = appendRarityToNoun(nouns);
+  const nounsWithRarity = shouldShowRarity ? appendRarityToNoun(nouns) : nouns;
   return (
     <Container>
       <Row className={classes.headerRow}>

--- a/packages/nouns-webapp/src/pages/HistoricalNouns/index.tsx
+++ b/packages/nouns-webapp/src/pages/HistoricalNouns/index.tsx
@@ -99,7 +99,7 @@ const HistoryPage = () => {
           return <Col>{nounContent(noun)}</Col>;
         })}
         {isLoadingMore ? (
-          'loading...'
+          <Spinner animation='border'/>
         ) : (
           <Button variant="light" onClick={() => loadMore()}>
             Load More

--- a/packages/nouns-webapp/src/pages/HistoricalNouns/index.tsx
+++ b/packages/nouns-webapp/src/pages/HistoricalNouns/index.tsx
@@ -2,7 +2,7 @@ import { useQuery } from '@apollo/client';
 import { BigNumber } from 'ethers';
 import { Tuple } from 'ramda';
 import { useState } from 'react';
-import { Button, Col, Container, Row } from 'react-bootstrap';
+import { Button, Col, Container, Row, Spinner } from 'react-bootstrap';
 import { StandaloneNounWithPreloadedSeed } from '../../components/StandaloneNoun';
 import { INounSeed } from '../../wrappers/nounToken';
 import { allNounQuery } from '../../wrappers/subgraph';
@@ -13,7 +13,7 @@ interface Noun {
   seed: INounSeed;
   traitRarity?: Map<string, Tuple<number, number>>;
 }
-const LIMIT = 69;
+const LIMIT = 1000;
 const HistoryPage = () => {
   const { loading, error, data, fetchMore } = useQuery(allNounQuery(), {
     variables: {
@@ -51,6 +51,9 @@ const HistoryPage = () => {
     setIsLoadingMore(false);
   };
 
+  // assumes you have copmlete view of the nouns
+  // doesnt work with pagination after len(nouns) > LIMIT
+  // better to handle this in the subgraph probably
   const appendRarityToNoun = (nouns: Noun[]) => {
     return nouns.map(noun => {
       const rarity = new Map<string, any>();
@@ -69,7 +72,11 @@ const HistoryPage = () => {
   };
 
   if (loading) {
-    return <Container>Loading nouns... </Container>;
+    return (
+      <Container>
+        <Spinner animation="border" />
+      </Container>
+    );
   } else if (error) {
     return <Container>Failed to load nouns</Container>;
   }

--- a/packages/nouns-webapp/src/pages/Playground/index.tsx
+++ b/packages/nouns-webapp/src/pages/Playground/index.tsx
@@ -36,11 +36,18 @@ const nounsSDKLink = (
   />
 );
 
-const parseTraitName = (partName: string): string =>
+export const parseTraitName = (partName: string): string =>
   capitalizeFirstLetter(partName.substring(partName.indexOf('-') + 1));
 
-const capitalizeFirstLetter = (s: string): string => s.charAt(0).toUpperCase() + s.slice(1);
+export const capitalizeFirstLetter = (s: string): string => s.charAt(0).toUpperCase() + s.slice(1);
 
+export const traitTitles = ['background', 'body', 'accessory', 'head', 'glasses'];
+export const traitNames = [
+  ['cool', 'warm'],
+  ...Object.values(ImageData.images).map(i => {
+    return i.map(imageData => imageData.filename);
+  }),
+];
 const Playground: React.FC = () => {
   const [nounSvgs, setNounSvgs] = useState<string[]>();
   const [traits, setTraits] = useState<Trait[]>();
@@ -64,13 +71,6 @@ const Playground: React.FC = () => {
   );
 
   useEffect(() => {
-    const traitTitles = ['background', 'body', 'accessory', 'head', 'glasses'];
-    const traitNames = [
-      ['cool', 'warm'],
-      ...Object.values(ImageData.images).map(i => {
-        return i.map(imageData => imageData.filename);
-      }),
-    ];
     setTraits(
       traitTitles.map((value, index) => {
         return {

--- a/packages/nouns-webapp/src/wrappers/subgraph.ts
+++ b/packages/nouns-webapp/src/wrappers/subgraph.ts
@@ -77,7 +77,7 @@ export const nounQuery = (id: string) => gql`
 	noun(id:"${id}") {
 	  id
 	  seed {
-	  background
+	  	background
 		body
 		accessory
 		head
@@ -89,6 +89,24 @@ export const nounQuery = (id: string) => gql`
 	}
   }
  `;
+
+export const allNounQuery = () => gql`
+  query GetAllNouns($offset: Int, $limit: Int) {
+    auctions(orderBy: startTime, orderDirection: desc, first: $limit, skip: $offset) {
+      startTime
+      noun {
+        id
+        seed {
+          background
+          body
+          accessory
+          head
+          glasses
+        }
+      }
+    }
+  }
+`;
 
 export const nounsIndex = () => gql`
   {


### PR DESCRIPTION
- added a history tab on the navbar
- created a history page
  - gets all nouns via (new) subgraph query
  - shows all the traits 
  - shows all the rarities of each trait (if enabled)
  - links back to the noun page