### PR TITLE
Dynamically set the homepage document title based on the time remaining

### DIFF
--- a/packages/nouns-webapp/src/components/AuctionTimer/index.tsx
+++ b/packages/nouns-webapp/src/components/AuctionTimer/index.tsx
@@ -5,6 +5,7 @@ import classes from './AuctionTimer.module.css';
 import { useState, useEffect, useRef } from 'react';
 import { Row, Col } from 'react-bootstrap';
 import { useAppSelector } from '../../hooks';
+import useDocumentTitle from '../../hooks/useDocumentTitle';
 import clsx from 'clsx';
 
 dayjs.extend(duration);
@@ -45,10 +46,21 @@ const AuctionTimer: React.FC<{
 
   const auctionContentLong = auctionEnded ? 'Auction ended' : 'Auction ends in';
   const auctionContentShort = auctionEnded ? 'Auction ended' : 'Time left';
-
+  const flooredHours = Math.floor(timerDuration.hours());
   const flooredMinutes = Math.floor(timerDuration.minutes());
   const flooredSeconds = Math.floor(timerDuration.seconds());
   const isCool = useAppSelector(state => state.application.isCoolBackground);
+
+  // Dynamically sets the document title based on `timerToggler` and `auctionTime` remaining
+  let docTitle = `${flooredHours}h ${flooredMinutes}m`;
+  if (timerToggle) {
+    // Update every second when time remaining is less than 5 minutes
+    if (auctionTimer < 300) docTitle = `${docTitle} ${flooredSeconds}s`;
+  } else {
+    docTitle = endTime.format('h:mm:ss a');
+  }
+  docTitle = `(${docTitle})`;
+  useDocumentTitle(auctionTimer ? docTitle : null);
 
   if (!auction) return null;
 
@@ -80,19 +92,19 @@ const AuctionTimer: React.FC<{
           >
             <div className={classes.timerSection}>
               <span>
-                {`${Math.floor(timerDuration.hours())}`}
+                {flooredHours}
                 <span className={classes.small}>h</span>
               </span>
             </div>
             <div className={classes.timerSection}>
               <span>
-                {`${flooredMinutes}`}
+                {flooredMinutes}
                 <span className={classes.small}>m</span>
               </span>
             </div>
             <div className={classes.timerSectionFinal}>
               <span>
-                {`${flooredSeconds}`}
+                {flooredSeconds}
                 <span className={classes.small}>s</span>
               </span>
             </div>

--- a/packages/nouns-webapp/src/hooks/useDocumentTitle.ts
+++ b/packages/nouns-webapp/src/hooks/useDocumentTitle.ts
@@ -1,0 +1,32 @@
+import { useRef, useEffect } from 'react';
+
+/**
+ * Dynamically append a string to the browser title. The title can optionally be replaced. Based on https://dev.to/luispa/how-to-add-a-dynamic-title-on-your-react-app-1l7k
+ * @param title string to set as the document title.
+ * @param replaceTitle replace the document title instead of appending. Default: false
+ * @param resetUnmount reset to the previous title when the component is unmounted. Default: true
+ */
+function useDocumentTitle(
+  title: string | undefined | null,
+  replaceTitle = false,
+  resetUnmount = true,
+) {
+  const defaultTitle = useRef(document.title);
+
+  useEffect(() => {
+    if (!title) return;
+    document.title = replaceTitle ? title : `${defaultTitle.current} ${title}`;
+  }, [title, replaceTitle]);
+
+  // Resets the title if `resetUnmount == true`
+  useEffect(
+    () => () => {
+      if (resetUnmount) {
+        document.title = defaultTitle.current;
+      }
+    },
+    [resetUnmount],
+  );
+}
+
+export default useDocumentTitle;


### PR DESCRIPTION
Sets the document title to the auction countdown timer if it's toggled on. If it's off, set the title to the end time of the auction. The countdown timer displays the seconds remaining only when the auction has less than 5 minutes remaining.

**Greater than 5 minutes remaining and timer toggled on**
![image](https://user-images.githubusercontent.com/83411264/157302609-acc8b981-034f-4cd5-879e-3e858ef86823.png)

**Less than 5 minutes remaining and timer toggled on**
![image](https://user-images.githubusercontent.com/83411264/157302304-f2d84862-2a5e-4664-8713-9f68f6598a17.png)

**Timer toggled off**
![image](https://user-images.githubusercontent.com/83411264/157301770-392effe2-c0c6-4101-8880-317ac3d0404d.png)
