### PR TITLE
Vote Page Bug Fixes

### DIFF
--- a/packages/nouns-webapp/src/components/NounImageVoteTable/index.tsx
+++ b/packages/nouns-webapp/src/components/NounImageVoteTable/index.tsx
@@ -30,17 +30,21 @@ const NounImageVoteTable: React.FC<NounImageVoteTableProps> = props => {
     return Array(rows)
       .fill(0)
       .map((_, i) => (
-        <tr>
+        <tr key={i}>
           {Array(rowLength)
             .fill(0)
             .map((_, j) => (
-              <td>{paddedNounIds[i * rowLength + j]}</td>
+              <td key={j}>{paddedNounIds[i * rowLength + j]}</td>
             ))}
         </tr>
       ));
   };
 
-  return <table className={classes.wrapper}>{content()}</table>;
+  return (
+    <table className={classes.wrapper}>
+      <tbody>{content()}</tbody>
+    </table>
+  );
 };
 
 export default NounImageVoteTable;

--- a/packages/nouns-webapp/src/components/ProposalHeader/index.tsx
+++ b/packages/nouns-webapp/src/components/ProposalHeader/index.tsx
@@ -44,6 +44,7 @@ const ProposalHeader: React.FC<ProposalHeaderProps> = props => {
             ? classes.submitBtn
             : classes.submitBtnDisabled
         }
+        disabled={!isWalletConnected || !connectedAccountNounVotes}
         onClick={submitButtonClickHandler}
       >
         Submit vote

--- a/packages/nouns-webapp/src/pages/Vote/index.tsx
+++ b/packages/nouns-webapp/src/pages/Vote/index.tsx
@@ -27,7 +27,7 @@ import {
   proposalVotesQuery,
   delegateNounsAtBlockQuery,
   ProposalVotes,
-  DelegatesNouns,
+  Delegates,
 } from '../../wrappers/subgraph';
 import { getNounVotes } from '../../utils/getNounsVotes';
 
@@ -192,12 +192,9 @@ const VotePage = ({
     loading: delegatesLoading,
     error: delegatesError,
     data: delegateSnapshot,
-  } = useQuery<DelegatesNouns>(
-    delegateNounsAtBlockQuery(voterIds ?? [], proposal?.createdBlock ?? 0),
-    {
-      skip: !voters?.votes?.length,
-    },
-  );
+  } = useQuery<Delegates>(delegateNounsAtBlockQuery(voterIds ?? [], proposal?.createdBlock ?? 0), {
+    skip: !voters?.votes?.length,
+  });
   const loading = votesLoading || delegatesLoading;
   const error = votesError || delegatesError;
 

--- a/packages/nouns-webapp/src/pages/Vote/index.tsx
+++ b/packages/nouns-webapp/src/pages/Vote/index.tsx
@@ -23,9 +23,13 @@ import ProposalHeader from '../../components/ProposalHeader';
 import ProposalContent from '../../components/ProposalContent';
 import VoteCard, { VoteCardVariant } from '../../components/VoteCard';
 import { useQuery } from '@apollo/client';
-import { nounVotesForProposalQuery } from '../../wrappers/subgraph';
+import {
+  proposalVotesQuery,
+  delegateNounsAtBlockQuery,
+  ProposalVotes,
+  DelegatesNouns,
+} from '../../wrappers/subgraph';
 import { getNounVotes } from '../../utils/getNounsVotes';
-
 
 dayjs.extend(utc);
 dayjs.extend(timezone);
@@ -177,9 +181,36 @@ const VotePage = ({
   );
 
   const activeAccount = useAppSelector(state => state.account.activeAccount);
-  const { loading, error, data } = useQuery(
-    nounVotesForProposalQuery(proposal && proposal.id ? proposal?.id : '0'),
+  const {
+    loading: votesLoading,
+    error: votesError,
+    data: voters,
+  } = useQuery<ProposalVotes>(proposalVotesQuery(proposal?.id ?? '0'));
+
+  const voterIds = voters?.votes?.map(v => v.voter.id);
+  const {
+    loading: delegatesLoading,
+    error: delegatesError,
+    data: delegateSnapshot,
+  } = useQuery<DelegatesNouns>(
+    delegateNounsAtBlockQuery(voterIds ?? [], proposal?.createdBlock ?? 0),
+    {
+      skip: !voters,
+    },
   );
+  const loading = votesLoading || delegatesLoading;
+  const error = votesError || delegatesError;
+
+  const { delegates } = delegateSnapshot || {};
+  const delegateToNounIds = delegates?.reduce<Record<string, string[]>>((acc, curr) => {
+    acc[curr.id] = curr?.nounsRepresented?.map(nr => nr.id) ?? [];
+    return acc;
+  }, {});
+
+  const data = voters?.votes?.map(v => ({
+    supportDetailed: v.supportDetailed,
+    nounsRepresented: delegateToNounIds?.[v.voter.id] ?? [],
+  }));
 
   const [showToast, setShowToast] = useState(true);
   useEffect(() => {
@@ -190,7 +221,7 @@ const VotePage = ({
     }
   }, [showToast]);
 
-  if (!proposal || loading || !data || data.proposals.length === 0) {
+  if (!proposal || loading || !data) {
     return (
       <div className={classes.spinner}>
         <Spinner animation="border" />

--- a/packages/nouns-webapp/src/pages/Vote/index.tsx
+++ b/packages/nouns-webapp/src/pages/Vote/index.tsx
@@ -195,7 +195,7 @@ const VotePage = ({
   } = useQuery<DelegatesNouns>(
     delegateNounsAtBlockQuery(voterIds ?? [], proposal?.createdBlock ?? 0),
     {
-      skip: !voters,
+      skip: !voters?.votes?.length,
     },
   );
   const loading = votesLoading || delegatesLoading;

--- a/packages/nouns-webapp/src/utils/getNounsVotes.ts
+++ b/packages/nouns-webapp/src/utils/getNounsVotes.ts
@@ -1,4 +1,4 @@
-interface NounVote {
+interface Vote {
   supportDetailed: 0 | 1 | 2;
   nounsRepresented: string[];
 }
@@ -10,6 +10,6 @@ interface NounVote {
  * @param supportDetailed - The integer support value: against (0), for (1), or abstain (2)
  * @returns - flat list of nounIds that voted supportDetailed for the given prop
  */
-export const getNounVotes = (votes: NounVote[], supportDetailed: number) => {
+export const getNounVotes = (votes: Vote[], supportDetailed: number) => {
   return votes.filter(v => v.supportDetailed === supportDetailed).flatMap(v => v.nounsRepresented);
 };

--- a/packages/nouns-webapp/src/utils/getNounsVotes.ts
+++ b/packages/nouns-webapp/src/utils/getNounsVotes.ts
@@ -1,14 +1,15 @@
+interface NounVote {
+  supportDetailed: 0 | 1 | 2;
+  nounsRepresented: string[];
+}
+
 /**
  * Helper function to transform response from graph into flat list of nounIds that voted supportDetailed for the given prop
  *
- * @param data - Graph response for noun vote query
+ * @param votes - Graph response for noun vote query
  * @param supportDetailed - The integer support value: against (0), for (1), or abstain (2)
  * @returns - flat list of nounIds that voted supportDetailed for the given prop
  */
-export const getNounVotes = (data: any, supportDetailed: number) => {
-  return data.proposals[0].votes
-    .filter((vote: any) => vote.supportDetailed === supportDetailed)
-    .map((vote: any) => vote.nouns)
-    .flat(1)
-    .map((noun: any) => noun.id);
+export const getNounVotes = (votes: NounVote[], supportDetailed: number) => {
+  return votes.filter(v => v.supportDetailed === supportDetailed).flatMap(v => v.nounsRepresented);
 };

--- a/packages/nouns-webapp/src/wrappers/subgraph.ts
+++ b/packages/nouns-webapp/src/wrappers/subgraph.ts
@@ -19,6 +19,28 @@ export interface IBid {
   };
 }
 
+interface ProposalVote {
+  supportDetailed: 0 | 1 | 2;
+  voter: {
+    id: string;
+  };
+}
+
+export interface ProposalVotes {
+  votes: ProposalVote[];
+}
+
+export interface DelegateNouns {
+  id: string;
+  nounsRepresented: {
+    id: string;
+  }[];
+}
+
+export interface DelegatesNouns {
+  delegates: DelegateNouns[];
+}
+
 export const auctionQuery = (auctionId: number) => gql`
 {
 	auction(id: ${auctionId}) {
@@ -181,16 +203,25 @@ export const createTimestampAllProposals = () => gql`
   }
 `;
 
-export const nounVotesForProposalQuery = (proposalId: string) => gql`
-{
-	proposals(where: {id: ${proposalId}}) {
-    votes {
+export const proposalVotesQuery = (proposalId: string) => gql`
+  {
+    votes(where: { proposal: "${proposalId}", votesRaw_gt: 0 }) {
       supportDetailed
-      nouns {
+      voter {
         id
       }
+    }	
+  }
+`;
+
+export const delegateNounsAtBlockQuery = (delegates: string[], block: number) => gql`
+{
+  delegates(where: { id_in: ${JSON.stringify(delegates)} }, block: { number: ${block} }) {
+    id
+    nounsRepresented {
+      id
     }
-  }	
+  }
 }
 `;
 

--- a/packages/nouns-webapp/src/wrappers/subgraph.ts
+++ b/packages/nouns-webapp/src/wrappers/subgraph.ts
@@ -30,15 +30,15 @@ export interface ProposalVotes {
   votes: ProposalVote[];
 }
 
-export interface DelegateNouns {
+export interface Delegate {
   id: string;
   nounsRepresented: {
     id: string;
   }[];
 }
 
-export interface DelegatesNouns {
-  delegates: DelegateNouns[];
+export interface Delegates {
+  delegates: Delegate[];
 }
 
 export const auctionQuery = (auctionId: number) => gql`


### PR DESCRIPTION
This PR resolves #391 and #392.

For #391, the vote counts were correct, but the Noun images were not. We were pulling current Noun delegate information, rather than details from the time the proposal was created. The quick fix for this issue requires two calls - one to fetch the voter ids and a second time-travel request to fetch the Noun information from the proposal creation block. This can be reduced to a single call via a larger change to the subgraph in the future.