### PR TITLE
Frontend Support for `castVoteWithReason` + Bug Fixes

### DIFF
--- a/packages/nouns-webapp/src/components/ProposalHeader/index.tsx
+++ b/packages/nouns-webapp/src/components/ProposalHeader/index.tsx
@@ -22,7 +22,7 @@ const ProposalHeader: React.FC<ProposalHeaderProps> = props => {
   const { proposal, isActiveForVoting, isWalletConnected, submitButtonClickHandler } = props;
 
   const isMobile = isMobileScreen();
-  const availableVotes = useUserVotesAsOfBlock(proposal?.createdBlock ?? undefined) ?? 0;
+  const availableVotes = useUserVotesAsOfBlock(proposal?.createdBlock) ?? 0;
   const hasVoted = useHasVotedOnProposal(proposal?.id);
   const proposalVote = useProposalVote(proposal?.id);
   const proposalCreationTimestamp = useBlockTimestamp(proposal?.createdBlock);
@@ -31,7 +31,7 @@ const ProposalHeader: React.FC<ProposalHeaderProps> = props => {
   const voteButton = (
     <>
       {isWalletConnected ? (
-        <>{availableVotes === 0 && <div className={classes.noVotesText}>You have no votes.</div>}</>
+        <>{!availableVotes && <div className={classes.noVotesText}>You have no votes.</div>}</>
       ) : (
         <div className={classes.connectWalletText}>Connect a wallet to vote.</div>
       )}

--- a/packages/nouns-webapp/src/components/ProposalHeader/index.tsx
+++ b/packages/nouns-webapp/src/components/ProposalHeader/index.tsx
@@ -26,6 +26,7 @@ const ProposalHeader: React.FC<ProposalHeaderProps> = props => {
   const hasVoted = useHasVotedOnProposal(proposal?.id);
   const proposalVote = useProposalVote(proposal?.id);
   const proposalCreationTimestamp = useBlockTimestamp(proposal?.createdBlock);
+  const disableVoteButton = !isWalletConnected || !connectedAccountNounVotes || hasVoted;
 
   const voteButton = (
     <>
@@ -39,12 +40,8 @@ const ProposalHeader: React.FC<ProposalHeaderProps> = props => {
         <div className={classes.connectWalletText}>Connect a wallet to vote.</div>
       )}
       <Button
-        className={
-          isWalletConnected && connectedAccountNounVotes > 0 && !hasVoted
-            ? classes.submitBtn
-            : classes.submitBtnDisabled
-        }
-        disabled={!isWalletConnected || !connectedAccountNounVotes || hasVoted}
+        className={disableVoteButton ? classes.submitBtnDisabled : classes.submitBtn}
+        disabled={disableVoteButton}
         onClick={submitButtonClickHandler}
       >
         Submit vote

--- a/packages/nouns-webapp/src/components/ProposalHeader/index.tsx
+++ b/packages/nouns-webapp/src/components/ProposalHeader/index.tsx
@@ -85,7 +85,7 @@ const ProposalHeader: React.FC<ProposalHeaderProps> = props => {
         </Alert>
       )}
 
-      {proposal && isActiveForVoting && proposalCreationTimestamp && !availableVotes && (
+      {proposal && isActiveForVoting && proposalCreationTimestamp && availableVotes && !hasVoted && (
         <Alert variant="success" className={classes.voterIneligibleAlert}>
           Only Nouns you owned or were delegated to you before{' '}
           {dayjs.unix(proposalCreationTimestamp).format('MMMM D, YYYY h:mm A z')} are eligible to

--- a/packages/nouns-webapp/src/components/ProposalHeader/index.tsx
+++ b/packages/nouns-webapp/src/components/ProposalHeader/index.tsx
@@ -40,11 +40,11 @@ const ProposalHeader: React.FC<ProposalHeaderProps> = props => {
       )}
       <Button
         className={
-          isWalletConnected && connectedAccountNounVotes > 0
+          isWalletConnected && connectedAccountNounVotes > 0 && !hasVoted
             ? classes.submitBtn
             : classes.submitBtnDisabled
         }
-        disabled={!isWalletConnected || !connectedAccountNounVotes}
+        disabled={!isWalletConnected || !connectedAccountNounVotes || hasVoted}
         onClick={submitButtonClickHandler}
       >
         Submit vote

--- a/packages/nouns-webapp/src/components/SettleManuallyBtn/index.tsx
+++ b/packages/nouns-webapp/src/components/SettleManuallyBtn/index.tsx
@@ -4,6 +4,7 @@ import classes from './SettleManuallyBtn.module.css';
 import dayjs from 'dayjs';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faInfoCircle } from '@fortawesome/free-solid-svg-icons';
+import { CHAIN_ID } from '../../config';
 
 const SettleManuallyBtn: React.FC<{
   settleAuctionHandler: () => void;
@@ -22,9 +23,15 @@ const SettleManuallyBtn: React.FC<{
 
   // timer logic
   useEffect(() => {
-    const timeLeft =
-      MINS_TO_ENABLE_MANUAL_SETTLEMENT * 60 -
-      (dayjs().unix() - (auction && Number(auction.endTime)));
+    // Allow immediate manual settlement when testing
+    if (CHAIN_ID !== 1) {
+      setSettleEnabled(true);
+      setAuctionTimer(0);
+      return;
+    }
+
+    // prettier-ignore
+    const timeLeft = MINS_TO_ENABLE_MANUAL_SETTLEMENT * 60 - (dayjs().unix() - (auction && Number(auction.endTime)));
 
     setAuctionTimer(auction && timeLeft);
 
@@ -34,7 +41,7 @@ const SettleManuallyBtn: React.FC<{
     } else {
       const timer = setTimeout(() => {
         setAuctionTimer(auctionTimerRef.current - 1);
-      }, 1000);
+      }, 1_000);
 
       return () => {
         clearTimeout(timer);

--- a/packages/nouns-webapp/src/components/StandaloneNoun/index.tsx
+++ b/packages/nouns-webapp/src/components/StandaloneNoun/index.tsx
@@ -93,8 +93,9 @@ export const StandaloneNounWithSeed: React.FC<StandaloneNounWithSeedProps> = (
 
   const dispatch = useDispatch();
   const seed = useNounSeed(nounId);
+  const seedIsInvalid = Object.values(seed || {}).every(v => v === 0);
 
-  if (!seed || !nounId || !onLoadSeed) return <Noun imgPath="" alt="Noun" />;
+  if (!seed || seedIsInvalid || !nounId || !onLoadSeed) return <Noun imgPath="" alt="Noun" />;
 
   onLoadSeed(seed);
 

--- a/packages/nouns-webapp/src/components/VoteModal/VoteModal.module.css
+++ b/packages/nouns-webapp/src/components/VoteModal/VoteModal.module.css
@@ -102,3 +102,16 @@
   font-weight: bold;
   color: var(--brand-color-red);
 }
+
+.voteReasonTextarea {
+  padding-top: 2rem !important;
+  height: 6.5rem !important;
+  border-radius: 10px;
+  border: none;
+  font-weight: bold;
+  font-size: 1rem;
+}
+
+.voteReasonTextarea:focus {
+  box-shadow: none;
+}

--- a/packages/nouns-webapp/src/pages/Vote/index.tsx
+++ b/packages/nouns-webapp/src/pages/Vote/index.tsx
@@ -100,19 +100,18 @@ const VotePage = ({
   const startOrEndTimeCopy = () => {
     if (startDate?.isBefore(now) && endDate?.isAfter(now)) {
       return 'Ends';
-    } else if (endDate?.isBefore(now)) {
-      return 'Ended';
-    } else {
-      return 'Starts';
     }
+    if (endDate?.isBefore(now)) {
+      return 'Ended';
+    }
+    return 'Starts';
   };
 
   const startOrEndTimeTime = () => {
     if (!startDate?.isBefore(now)) {
       return startDate;
-    } else {
-      return endDate;
     }
+    return endDate;
   };
 
   const moveStateButtonAction = hasSucceeded ? 'Queue' : 'Execute';

--- a/packages/nouns-webapp/src/wrappers/nounsDao.ts
+++ b/packages/nouns-webapp/src/wrappers/nounsDao.ts
@@ -311,6 +311,14 @@ export const useCastVote = () => {
   return { castVote, castVoteState };
 };
 
+export const useCastVoteWithReason = () => {
+  const { send: castVoteWithReason, state: castVoteWithReasonState } = useContractFunction(
+    nounsDaoContract,
+    'castVoteWithReason',
+  );
+  return { castVoteWithReason, castVoteWithReasonState };
+};
+
 export const usePropose = () => {
   const { send: propose, state: proposeState } = useContractFunction(nounsDaoContract, 'propose');
   return { propose, proposeState };

--- a/packages/nouns-webapp/src/wrappers/onDisplayAuction.ts
+++ b/packages/nouns-webapp/src/wrappers/onDisplayAuction.ts
@@ -52,25 +52,25 @@ const useOnDisplayAuction = (): Auction | undefined => {
   // current auction
   if (BigNumber.from(onDisplayAuctionNounId).eq(lastAuctionNounId)) {
     return deserializeAuction(currentAuction);
-  } else {
-    // nounder auction
-    if (isNounderNoun(BigNumber.from(onDisplayAuctionNounId))) {
-      const emptyNounderAuction = generateEmptyNounderAuction(
-        BigNumber.from(onDisplayAuctionNounId),
-        pastAuctions,
-      );
-
-      return deserializeAuction(emptyNounderAuction);
-    } else {
-      // past auction
-      const reduxSafeAuction: Auction | undefined = pastAuctions.find(auction => {
-        const nounId = auction.activeAuction && BigNumber.from(auction.activeAuction.nounId);
-        return nounId && nounId.toNumber() === onDisplayAuctionNounId;
-      })?.activeAuction;
-
-      return reduxSafeAuction ? deserializeAuction(reduxSafeAuction) : undefined;
-    }
   }
+
+  // nounder auction
+  if (isNounderNoun(BigNumber.from(onDisplayAuctionNounId))) {
+    const emptyNounderAuction = generateEmptyNounderAuction(
+      BigNumber.from(onDisplayAuctionNounId),
+      pastAuctions,
+    );
+
+    return deserializeAuction(emptyNounderAuction);
+  }
+
+  // past auction
+  const reduxSafeAuction: Auction | undefined = pastAuctions.find(auction => {
+    const nounId = auction.activeAuction && BigNumber.from(auction.activeAuction.nounId);
+    return nounId && nounId.toNumber() === onDisplayAuctionNounId;
+  })?.activeAuction;
+
+  return reduxSafeAuction ? deserializeAuction(reduxSafeAuction) : undefined;
 };
 
 export const useAuctionBids = (auctionNounId: BigNumber): Bid[] | undefined => {


### PR DESCRIPTION
This PR enables Nouners to add an optional reason for their vote:

<img width="400" alt="reason" src="https://user-images.githubusercontent.com/85371573/162814349-57896a51-f09c-4c9d-8973-23af07f1cbad.png">

In addition, the following bug fixes are included:

* Use vote counts at time of proposal creation to determine if a user can submit a vote.
* Prevent voter from accidentally queuing multiple vote transactions by clicking the vote button multiple times.
* Disable vote button if vote has already been cast.
* Show loader, rather than aardvark, in the seconds following auction settlement.

**Note:** Bot support for vote reasons will be added in a separate PR as governance handling has not yet been merged to master.

Bot PR: https://github.com/nounsDAO/nouns-monorepo/pull/423

https://github.com/nounsDAO/nouns-monorepo/issues/307 can be closed once #422 and #423 are merged.