### PR TITLE
Surface Vote Reason in Discord (If Applicable)

### DIFF
--- a/packages/nouns-bots/src/handlers/discord.ts
+++ b/packages/nouns-bots/src/handlers/discord.ts
@@ -88,8 +88,4 @@ export class DiscordAuctionLifecycleHandler implements IAuctionLifecycleHandler 
     await Promise.all(this.discordClients.map(c => c.send(message)));
     console.log(`processed discord new vote for proposal ${proposal.id};${vote.id}`);
   }
-
-  async handleAuctionEndingSoon(_auctionId: number) {
-    return;
-  }
 }

--- a/packages/nouns-bots/src/index.ts
+++ b/packages/nouns-bots/src/index.ts
@@ -77,7 +77,9 @@ async function processAuctionTick() {
   const secondsUntilAuctionEnds = endTime - currentTimestamp;
   if (secondsUntilAuctionEnds < 20 * 60 && cachedAuctionEndingSoon < lastAuctionId) {
     await updateAuctionEndingSoonCache(lastAuctionId);
-    await Promise.all(auctionLifecycleHandlers.map(h => h.handleAuctionEndingSoon(lastAuctionId)));
+    await Promise.all(
+      auctionLifecycleHandlers.map(h => h.handleAuctionEndingSoon?.(lastAuctionId)),
+    );
   }
 }
 

--- a/packages/nouns-bots/src/subgraph.ts
+++ b/packages/nouns-bots/src/subgraph.ts
@@ -57,6 +57,7 @@ export async function getAllProposals(): Promise<Proposal[]> {
             }
             votes
             supportDetailed
+            reason
           }
         }
       }

--- a/packages/nouns-bots/src/types.ts
+++ b/packages/nouns-bots/src/types.ts
@@ -32,7 +32,7 @@ export interface TokenMetadata {
 export interface IAuctionLifecycleHandler {
   handleNewAuction(auctionId: number): Promise<void>;
   handleNewBid(auctionId: number, bid: Bid): Promise<void>;
-  handleAuctionEndingSoon(auctionId: number): Promise<void>;
+  handleAuctionEndingSoon?(auctionId: number): Promise<void>;
   handleNewProposal?(proposal: Proposal): Promise<void>;
   handleUpdatedProposalStatus?(proposal: Proposal): Promise<void>;
   handleProposalAtRiskOfExpiry?(proposal: Proposal): Promise<void>;
@@ -79,4 +79,5 @@ export interface Vote {
   voter: Account;
   votes: number;
   supportDetailed: VoteDirection;
+  reason: string | null;
 }

--- a/packages/nouns-bots/src/utils.ts
+++ b/packages/nouns-bots/src/utils.ts
@@ -76,7 +76,7 @@ export function formatProposalAtRiskOfExpiryText(proposal: Proposal) {
 export async function formatNewGovernanceVoteText(proposal: Proposal, vote: Vote) {
   return `${await resolveEnsOrFormatAddress(vote.voter.id)} has voted ${voteDirectionToText(
     vote.supportDetailed,
-  )} Proposal #${proposal.id}.${vote.reason ? `\n\nReason: ${vote.reason}` : ''}`;
+  )} Proposal #${proposal.id}${vote.reason ? `.\n\nReason: ${vote.reason}` : ''}`;
 }
 
 /**

--- a/packages/nouns-bots/src/utils.ts
+++ b/packages/nouns-bots/src/utils.ts
@@ -76,7 +76,7 @@ export function formatProposalAtRiskOfExpiryText(proposal: Proposal) {
 export async function formatNewGovernanceVoteText(proposal: Proposal, vote: Vote) {
   return `${await resolveEnsOrFormatAddress(vote.voter.id)} has voted ${voteDirectionToText(
     vote.supportDetailed,
-  )} Proposal #${proposal.id}`;
+  )} Proposal #${proposal.id}.${vote.reason ? `\n\nReason: ${vote.reason}` : ''}`;
 }
 
 /**

--- a/packages/nouns-bots/src/utils/proposals.ts
+++ b/packages/nouns-bots/src/utils/proposals.ts
@@ -45,7 +45,9 @@ export const parseVote = (vote: Vote): Vote => ({
  */
 export const extractNewVotes = (proposalBefore: Proposal, proposalAfter: Proposal): Vote[] => {
   const previousStateVoteIds = R.map(R.prop('id'), proposalBefore.votes);
-  return proposalAfter.votes.filter(vote => previousStateVoteIds.indexOf(vote.id) === -1);
+  return proposalAfter.votes.filter(
+    vote => previousStateVoteIds.indexOf(vote.id) === -1 && vote.votes > 0,
+  );
 };
 
 /**

--- a/packages/nouns-subgraph/schema.graphql
+++ b/packages/nouns-subgraph/schema.graphql
@@ -204,6 +204,9 @@ type Vote @entity {
   "Amount of votes in favour or against expressed as a BigInt normalized value for the Nouns ERC721 Token"
   votes: BigInt!
 
+  "The optional vote reason"
+  reason: String
+
   "Delegate that emitted the vote"
   voter: Delegate!
 

--- a/packages/nouns-subgraph/src/nouns-dao.ts
+++ b/packages/nouns-subgraph/src/nouns-dao.ts
@@ -124,6 +124,10 @@ export function handleVoteCast(event: VoteCast): void {
   vote.supportDetailed = event.params.support;
   vote.nouns = voter.nounsRepresented;
 
+  if (event.params.reason != '') {
+    vote.reason = event.params.reason;
+  }
+
   vote.save();
 
   if (proposal.status == STATUS_PENDING) {


### PR DESCRIPTION
This PR is the backend component of https://github.com/nounsDAO/nouns-monorepo/pull/422.

With this change, vote reasons will be surfaced in Discord vote notifications, if present.