### PR TITLE
Add basic content moderation for ens names

### DIFF
--- a/packages/nouns-webapp/package.json
+++ b/packages/nouns-webapp/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "@apollo/client": "^3.3.21",
+    "bad-words": "^3.0.4",
     "@davatar/react": "^1.8.1",
     "@heroicons/react": "^1.0.6",
     "@fortawesome/fontawesome-svg-core": "1.2.35",
@@ -58,6 +59,7 @@
     "@types/react": "^17.0.0",
     "@types/react-dom": "^17.0.0",
     "@types/react-router-dom": "^5.1.7",
+    "@types/bad-words": "^3.0.1",
     "dotenv": "^10.0.0"
   },
   "scripts": {

--- a/packages/nouns-webapp/src/components/BidHistoryModalRow/index.tsx
+++ b/packages/nouns-webapp/src/components/BidHistoryModalRow/index.tsx
@@ -14,6 +14,7 @@ import _trophy from '../../assets/icons/trophy.svg';
 import Davatar from '@davatar/react';
 import { useEthers } from '@usedapp/core';
 import { useReverseENSLookUp } from '../../utils/ensLookup';
+import { containsBlockedText } from '../../utils/moderation/containsBlockedText';
 
 interface BidHistoryModalRowProps {
   bid: Bid;
@@ -38,6 +39,7 @@ const BidHistoryModalRow: React.FC<BidHistoryModalRowProps> = props => {
   ).format('hh:mm a')}`;
 
   const ens = useReverseENSLookUp(bid.sender);
+  const ensMatchesBlocklistRegex = containsBlockedText(ens || '', 'en');
   const shortAddress = useShortAddress(bid.sender);
 
   return (
@@ -49,7 +51,7 @@ const BidHistoryModalRow: React.FC<BidHistoryModalRowProps> = props => {
               <Davatar size={40} address={bid.sender} provider={provider} />
               <div className={classes.bidderInfoText}>
                 <span>
-                  {ens ? shortENS(ens) : shortAddress}
+                  {ens && !ensMatchesBlocklistRegex ? shortENS(ens) : shortAddress}
                   {index === 0 && (
                     <img
                       src={_trophy}

--- a/packages/nouns-webapp/src/components/BidHistoryModalRow/index.tsx
+++ b/packages/nouns-webapp/src/components/BidHistoryModalRow/index.tsx
@@ -51,7 +51,13 @@ const BidHistoryModalRow: React.FC<BidHistoryModalRowProps> = props => {
                 <span>
                   {ens ? shortENS(ens) : shortAddress}
                   {index === 0 && (
-                    <img src={_trophy} alt="Winning bidder" className={classes.trophy} height={16} width={16} />
+                    <img
+                      src={_trophy}
+                      alt="Winning bidder"
+                      className={classes.trophy}
+                      height={16}
+                      width={16}
+                    />
                   )}
                   <br />
                   <div className={classes.bidDate}>{date}</div>

--- a/packages/nouns-webapp/src/components/ShortAddress/index.tsx
+++ b/packages/nouns-webapp/src/components/ShortAddress/index.tsx
@@ -13,7 +13,7 @@ const ShortAddress: React.FC<{ address: string; avatar?: boolean; size?: number 
   const { library: provider } = useEthers();
 
   const ens = useReverseENSLookUp(address);
-  const ensMatchesBlocklistRegex = containsBlockedText(ens || "", 'en');
+  const ensMatchesBlocklistRegex = containsBlockedText(ens || '', 'en');
   const shortAddress = useShortAddress(address);
 
   if (avatar) {
@@ -24,7 +24,7 @@ const ShortAddress: React.FC<{ address: string; avatar?: boolean; size?: number 
             <Davatar size={size} address={address} provider={provider} />
           </div>
         )}
-        <span>{ens  && !ensMatchesBlocklistRegex ? ens : shortAddress}</span>
+        <span>{ens && !ensMatchesBlocklistRegex ? ens : shortAddress}</span>
       </div>
     );
   }

--- a/packages/nouns-webapp/src/components/ShortAddress/index.tsx
+++ b/packages/nouns-webapp/src/components/ShortAddress/index.tsx
@@ -2,6 +2,7 @@ import { useReverseENSLookUp } from '../../utils/ensLookup';
 import { useEthers } from '@usedapp/core';
 import Davatar from '@davatar/react';
 import classes from './ShortAddress.module.css';
+import { containsBlockedText } from '../../utils/moderation/containsBlockedText';
 
 export const useShortAddress = (address: string) => {
   return address && [address.substr(0, 4), address.substr(38, 4)].join('...');
@@ -12,6 +13,7 @@ const ShortAddress: React.FC<{ address: string; avatar?: boolean; size?: number 
   const { library: provider } = useEthers();
 
   const ens = useReverseENSLookUp(address);
+  const ensMatchesBlocklistRegex = containsBlockedText(ens || "", 'en');
   const shortAddress = useShortAddress(address);
 
   if (avatar) {
@@ -22,7 +24,7 @@ const ShortAddress: React.FC<{ address: string; avatar?: boolean; size?: number 
             <Davatar size={size} address={address} provider={provider} />
           </div>
         )}
-        <span>{ens ? ens : shortAddress}</span>
+        <span>{ens  && !ensMatchesBlocklistRegex ? ens : shortAddress}</span>
       </div>
     );
   }

--- a/packages/nouns-webapp/src/utils/moderation/containsBlockedText.ts
+++ b/packages/nouns-webapp/src/utils/moderation/containsBlockedText.ts
@@ -1,4 +1,5 @@
 import moderationRegexes from './moderationRegexes.json';
+import Filter from 'bad-words';
 
 /**
  * Check if text matches a blocked phrase in a given langugae
@@ -12,14 +13,20 @@ export const containsBlockedText = (text: string, language: string) => {
   const regexesForLanguage = new Map(Object.entries(moderationRegexes)).get(language);
   // Default to letting the string through if the language is unsupprted
   if (regexesForLanguage === undefined) {
-    console.log(`Unsupported langugae ${language} requested`);
+    console.log(`Unsupported language ${language} requested`);
     return false;
   }
 
-  // Filter if we match at least one regex
+  // Filter based on bad-words profanity filters
+  const filter = new Filter();
+  if (filter.isProfane(text)) {
+    return true;
+  }
+
+  // Filter based on custom regexes
   return (
     regexesForLanguage
-      .map((entry: any) => {
+      .map((entry: { regex: string }) => {
         const regex = entry.regex;
         return text.match(regex) !== null;
       })

--- a/packages/nouns-webapp/src/utils/moderation/containsBlockedText.ts
+++ b/packages/nouns-webapp/src/utils/moderation/containsBlockedText.ts
@@ -1,25 +1,28 @@
-import moderationRegexes from "./moderationRegexes.json";  
+import moderationRegexes from './moderationRegexes.json';
 
 /**
  * Check if text matches a blocked phrase in a given langugae
- *  
- * @param text 
+ *
+ * @param text
  * @param language
  * @returns boolean true iif text matches a blocked word of phrase
  */
 export const containsBlockedText = (text: string, language: string) => {
+  // Get modearation regexes for language
+  const regexesForLanguage = new Map(Object.entries(moderationRegexes)).get(language);
+  // Default to letting the string through if the language is unsupprted
+  if (regexesForLanguage === undefined) {
+    console.log(`Unsupported langugae ${language} requested`);
+    return false;
+  }
 
-    // Get modearation regexes for language
-    const regexesForLanguage =  new Map(Object.entries(moderationRegexes)).get(language);
-    // Default to letting the string through if the language is unsupprted
-    if (regexesForLanguage === undefined) {
-        console.log(`Unsupported langugae ${language} requested`);
-        return false;
-    }
-
-    // Filter if we match at least one regex
-    return regexesForLanguage.map((entry: any) => {
+  // Filter if we match at least one regex
+  return (
+    regexesForLanguage
+      .map((entry: any) => {
         const regex = entry.regex;
         return text.match(regex) !== null;
-    }).filter((isRegexMatch: boolean) =>  isRegexMatch).length > 0;
+      })
+      .filter((isRegexMatch: boolean) => isRegexMatch).length > 0
+  );
 };

--- a/packages/nouns-webapp/src/utils/moderation/containsBlockedText.ts
+++ b/packages/nouns-webapp/src/utils/moderation/containsBlockedText.ts
@@ -1,0 +1,25 @@
+import moderationRegexes from "./moderationRegexes.json";  
+
+/**
+ * Check if text matches a blocked phrase in a given langugae
+ *  
+ * @param text 
+ * @param language
+ * @returns boolean true iif text matches a blocked word of phrase
+ */
+export const containsBlockedText = (text: string, language: string) => {
+
+    // Get modearation regexes for language
+    const regexesForLanguage =  new Map(Object.entries(moderationRegexes)).get(language);
+    // Default to letting the string through if the language is unsupprted
+    if (regexesForLanguage === undefined) {
+        console.log(`Unsupported langugae ${language} requested`);
+        return false;
+    }
+
+    // Filter if we match at least one regex
+    return regexesForLanguage.map((entry: any) => {
+        const regex = entry.regex;
+        return text.match(regex) !== null;
+    }).filter((isRegexMatch: boolean) =>  isRegexMatch).length > 0;
+};

--- a/packages/nouns-webapp/src/utils/moderation/moderationRegexes.json
+++ b/packages/nouns-webapp/src/utils/moderation/moderationRegexes.json
@@ -1,11 +1,11 @@
 {
-    "en": [
-        {
-            "regex": "kill.{0,3}all.{0,3}jew"
-        },
-        {
-            "regex": "hate.{0,3}jew"
-        }
-    ],
-    "jp": []
+  "en": [
+    {
+      "regex": "kill.{0,3}all.{0,3}jew"
+    },
+    {
+      "regex": "hate.{0,3}jew"
+    }
+  ],
+  "jp": []
 }

--- a/packages/nouns-webapp/src/utils/moderation/moderationRegexes.json
+++ b/packages/nouns-webapp/src/utils/moderation/moderationRegexes.json
@@ -1,0 +1,11 @@
+{
+    "en": [
+        {
+            "regex": "kill.{0,3}all.{0,3}jew"
+        },
+        {
+            "regex": "hate.{0,3}jew"
+        }
+    ],
+    "jp": []
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2130,6 +2130,11 @@
   dependencies:
     "@hapi/hoek" "^8.3.0"
 
+"@heroicons/react@^1.0.6":
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/@heroicons/react/-/react-1.0.6.tgz#35dd26987228b39ef2316db3b1245c42eb19e324"
+  integrity sha512-JJCXydOFWMDpCP4q13iEplA503MQO3xLoZiKum+955ZCtHINWnx26CUxVxxFQu/uLb4LW3ge15ZpzIkXKkJ8oQ==
+
 "@humanwhocodes/config-array@^0.5.0":
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.5.0.tgz#1407967d4c6eecd7388f83acf1eaf4d0c6e58ef9"
@@ -3871,6 +3876,11 @@
   integrity sha512-K2waXdXBi2302XUdcHcR1jCeU0LL4TD9HRs/gk0N2Xvrht+G/BfJa4QObBQZfhMdxiCpV3COl5Nfq4uKTeTnJA==
   dependencies:
     "@babel/types" "^7.3.0"
+
+"@types/bad-words@^3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@types/bad-words/-/bad-words-3.0.1.tgz#6a20fb08814af5e1f2428fa9e0098ca7b36f730a"
+  integrity sha512-7la3ZDJG1tlRqySO+pnXycZpacaMEw/iLEm8kc4l+I+jN8KjBfoQVwO6jm98xzXVLrxV8vDrB5TaMoop8sKclQ==
 
 "@types/bn.js@*", "@types/bn.js@^5.1.0":
   version "5.1.0"
@@ -6561,6 +6571,18 @@ backoff@^2.5.0:
   integrity sha1-9hbtqdPktmuMp/ynn2lXIsX44m8=
   dependencies:
     precond "0.2"
+
+bad-words@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/bad-words/-/bad-words-3.0.4.tgz#044c83935c4c363a905d47b5e0179f7241fecaec"
+  integrity sha512-v/Q9uRPH4+yzDVLL4vR1+S9KoFgOEUl5s4axd6NIAq8SV2mradgi4E8lma/Y0cw1ltVdvyegCQQKffCPRCp8fg==
+  dependencies:
+    badwords-list "^1.0.0"
+
+badwords-list@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/badwords-list/-/badwords-list-1.0.0.tgz#5e9856dbf13482a295c3b0b304afb9d4cfc5c579"
+  integrity sha1-XphW2/E0gqKVw7CzBK+51M/FxXk=
 
 bail@^2.0.0:
   version "2.0.2"


### PR DESCRIPTION
This pr adds logic to fallback to showing just ETH address when and ens matches a suite of regexes of unsavory words / phrases. 

## Before 
![Screen Shot 2022-04-19 at 9 31 27 AM](https://user-images.githubusercontent.com/12565062/164053329-cfd5c76c-a987-49dd-8e41-d61be7c43808.png)


## After

![Screen Shot 2022-04-19 at 9 37 17 AM](https://user-images.githubusercontent.com/12565062/164053343-d49ed299-6695-40b6-a908-5c1d0ba6cc5b.png)


# Some longer term thoughts

This is just a low hanging fruit solution. There are many ways a motivated attacker could still troll us. In particular, one attack vector here is that by having this logic in a public github repo we are showing all our cards so to speak. Probably not worth it in the near term but if moderation becomes a problem it might make sense to push this logic to a private api. 