### PR TITLE
Use Read-Only Provider to Fetch Logs

### DIFF
--- a/packages/nouns-webapp/src/hooks/useReadonlyProvider.ts
+++ b/packages/nouns-webapp/src/hooks/useReadonlyProvider.ts
@@ -1,0 +1,18 @@
+import { useMemo } from 'react';
+import { useConfig } from '@usedapp/core';
+import { providers } from 'ethers';
+import { CHAIN_ID } from '../config';
+
+/**
+ * Returns a provider that's constructed using the readonly RPC URL.
+ */
+export function useReadonlyProvider(): providers.JsonRpcProvider | undefined {
+  const config = useConfig();
+  const rpcURL = config?.readOnlyUrls?.[CHAIN_ID];
+  return useMemo(() => {
+    if (!rpcURL) {
+      return;
+    }
+    return new providers.JsonRpcProvider(rpcURL);
+  }, [rpcURL]);
+}

--- a/packages/nouns-webapp/src/state/updaters/logs.ts
+++ b/packages/nouns-webapp/src/state/updaters/logs.ts
@@ -1,6 +1,7 @@
-import { useBlockNumber, useEthers } from '@usedapp/core';
+import { useBlockNumber } from '@usedapp/core';
 import { useEffect, useMemo } from 'react';
 import { useAppDispatch, useAppSelector } from '../../hooks';
+import { useReadonlyProvider } from '../../hooks/useReadonlyProvider';
 import { EventFilter, keyToFilter } from '../../utils/logParsing';
 import { fetchedLogs, fetchedLogsError, fetchingLogs } from '../slices/logs';
 
@@ -9,7 +10,7 @@ const MAX_BLOCKS_PER_CALL = 1_000_000;
 const Updater = (): null => {
   const dispatch = useAppDispatch();
   const state = useAppSelector(state => state.logs);
-  const { library } = useEthers();
+  const provider = useReadonlyProvider();
 
   const blockNumber = useBlockNumber();
 
@@ -34,7 +35,7 @@ const Updater = (): null => {
   }, [blockNumber, state]);
 
   useEffect(() => {
-    if (!library || typeof blockNumber !== 'number' || filtersNeedFetch.length === 0) return;
+    if (!provider || typeof blockNumber !== 'number' || filtersNeedFetch.length === 0) return;
 
     dispatch(fetchingLogs({ filters: filtersNeedFetch, blockNumber }));
     filtersNeedFetch.forEach(filter => {
@@ -51,7 +52,7 @@ const Updater = (): null => {
 
       Promise.all(
         ranges.map(range =>
-          library.getLogs({
+          provider.getLogs({
             ...filter,
             ...range,
           }),
@@ -75,7 +76,7 @@ const Updater = (): null => {
           );
         });
     });
-  }, [blockNumber, dispatch, filtersNeedFetch, library]);
+  }, [blockNumber, dispatch, filtersNeedFetch, provider]);
 
   return null;
 };


### PR DESCRIPTION
Force `getLogs` to use the readonly provider, rather than the wallet provider. The wallet provider (Infura) times out far faster than Alchemy.