### PR TITLE
filter pre vote canceled props from noun profiles

### DIFF
--- a/packages/nouns-webapp/src/components/NavBar/index.tsx
+++ b/packages/nouns-webapp/src/components/NavBar/index.tsx
@@ -82,9 +82,13 @@ const NavBar = () => {
               )}
             </Nav.Item>
           </div>
-          <Navbar.Toggle className={classes.navBarToggle} aria-controls="basic-navbar-nav" onClick={() => setIsNavExpanded(!isNavExpanded)} />
+          <Navbar.Toggle
+            className={classes.navBarToggle}
+            aria-controls="basic-navbar-nav"
+            onClick={() => setIsNavExpanded(!isNavExpanded)}
+          />
           <Navbar.Collapse className="justify-content-end">
-            <Nav.Link as={Link} to="/vote" className={classes.nounsNavLink} onClick={closeNav} >
+            <Nav.Link as={Link} to="/vote" className={classes.nounsNavLink} onClick={closeNav}>
               <NavBarButton
                 buttonText={<Trans>DAO</Trans>}
                 buttonIcon={<FontAwesomeIcon icon={faUsers} />}
@@ -117,7 +121,12 @@ const NavBar = () => {
                 buttonStyle={nonWalletButtonStyle}
               />
             </Nav.Link>
-            <Nav.Link as={Link} to="/playground" className={classes.nounsNavLink}  onClick={closeNav}>
+            <Nav.Link
+              as={Link}
+              to="/playground"
+              className={classes.nounsNavLink}
+              onClick={closeNav}
+            >
               <NavBarButton
                 buttonText={<Trans>Playground</Trans>}
                 buttonIcon={<FontAwesomeIcon icon={faPlay} />}

--- a/packages/nouns-webapp/src/components/ProfileActivityFeed/index.tsx
+++ b/packages/nouns-webapp/src/components/ProfileActivityFeed/index.tsx
@@ -65,15 +65,22 @@ const ProfileActivityFeed: React.FC<ProfileActivityFeedProps> = props => {
     }, {});
 
   const filteredProposals = proposals.filter((p: Proposal, id: number) => {
-    return (
-      // Filter props from before the Noun was born
-      (parseInt(proposalCreatedTimestamps.proposals[id].createdTimestamp) >
-        nounCanVoteTimestamp.toNumber() ||
-        (p.id && nounVotes[p.id])) &&
-      // Filter props which were cancelled and got 0 votes of any kind
-      // This a hack to filter props that were cancelled before going live
-      !(p.status === ProposalState.CANCELLED && p.forCount + p.abstainCount + p.againstCount === 0)
+    const proposalCreationTimestamp = parseInt(
+      proposalCreatedTimestamps.proposals[id].createdTimestamp,
     );
+
+    // Filter props from before the Noun was born
+    if (nounCanVoteTimestamp.gt(proposalCreationTimestamp)) {
+      return false;
+    }
+    // Filter props which were cancelled and got 0 votes of any kind
+    if (
+      p.status === ProposalState.CANCELLED &&
+      p.forCount + p.abstainCount + p.againstCount === 0
+    ) {
+      return false;
+    }
+    return true;
   });
 
   return (

--- a/packages/nouns-webapp/src/components/ProfileActivityFeed/index.tsx
+++ b/packages/nouns-webapp/src/components/ProfileActivityFeed/index.tsx
@@ -4,7 +4,7 @@ import Section from '../../layout/Section';
 import classes from './ProfileActivityFeed.module.css';
 
 import { useQuery } from '@apollo/client';
-import { Proposal, useAllProposals } from '../../wrappers/nounsDao';
+import { Proposal, ProposalState, useAllProposals } from '../../wrappers/nounsDao';
 import { createTimestampAllProposals, nounVotingHistoryQuery } from '../../wrappers/subgraph';
 import NounProfileVoteRow from '../NounProfileVoteRow';
 import { LoadingNoun } from '../Noun';
@@ -66,9 +66,13 @@ const ProfileActivityFeed: React.FC<ProfileActivityFeedProps> = props => {
 
   const filteredProposals = proposals.filter((p: Proposal, id: number) => {
     return (
-      parseInt(proposalCreatedTimestamps.proposals[id].createdTimestamp) >
+      // Filter props from before the Noun was born
+      (parseInt(proposalCreatedTimestamps.proposals[id].createdTimestamp) >
         nounCanVoteTimestamp.toNumber() ||
-      (p.id && nounVotes[p.id])
+        (p.id && nounVotes[p.id])) &&
+      // Filter props which were cancelled and got 0 votes of any kind
+      // This a hack to filter props that were cancelled before going live
+      !(p.status === ProposalState.CANCELLED && p.forCount + p.abstainCount + p.againstCount === 0)
     );
   });
 

--- a/packages/nouns-webapp/src/components/ProposalHeader/ProposalHeader.module.css
+++ b/packages/nouns-webapp/src/components/ProposalHeader/ProposalHeader.module.css
@@ -160,7 +160,6 @@
   margin-left: 2.5rem;
 }
 
-
 .propTransactionHash {
   margin-left: 0.2rem;
 }

--- a/packages/nouns-webapp/src/components/ProposalHeader/index.tsx
+++ b/packages/nouns-webapp/src/components/ProposalHeader/index.tsx
@@ -139,9 +139,7 @@ const ProposalHeader: React.FC<ProposalHeaderProps> = props => {
           <div className={classes.proposalByLineWrapperJp}>
             <Trans>
               <span className={classes.proposedByJp}>Proposed by: </span>
-              <span className={classes.proposerJp}>
-              {proposer}
-              </span>
+              <span className={classes.proposerJp}>{proposer}</span>
               <span className={classes.propTransactionWrapperJp}>{proposedAtTransactionHash}</span>
             </Trans>
           </div>


### PR DESCRIPTION
TLDR:

re https://discord.com/channels/849745721544146955/877215225093451776/977694339176214529

This PR filters props that are cancelled and got 0 votes of any kind (for, against, abstain) from the profile activity feed. 

Testing done:

Confirmed by looking at profile activity feed that props cancelled before going to a vote were filtered