### PR TITLE
Fix `PENDING` -> `ACTIVE` Proposal State Transition

### DIFF
--- a/packages/nouns-webapp/src/wrappers/nounsDao.ts
+++ b/packages/nouns-webapp/src/wrappers/nounsDao.ts
@@ -298,6 +298,15 @@ const getProposalState = (
   proposal: ProposalSubgraphEntity,
 ) => {
   const status = ProposalState[proposal.status];
+  if (status === ProposalState.PENDING) {
+    if (!blockNumber) {
+      return ProposalState.UNDETERMINED;
+    }
+    if (blockNumber <= parseInt(proposal.startBlock)) {
+      return ProposalState.PENDING;
+    }
+    return ProposalState.ACTIVE;
+  }
   if (status === ProposalState.ACTIVE) {
     if (!blockNumber) {
       return ProposalState.UNDETERMINED;


### PR DESCRIPTION
This PR fixes an issue that caused active proposals to display as pending in the UI if no votes has been received.