### PR TITLE
Make sure that Delegate button shows iff account has non-zero Noun balance

### DIFF
--- a/packages/nouns-webapp/src/components/Proposals/index.tsx
+++ b/packages/nouns-webapp/src/components/Proposals/index.tsx
@@ -6,7 +6,7 @@ import { useHistory } from 'react-router-dom';
 import { useBlockNumber, useEthers } from '@usedapp/core';
 import { isMobileScreen } from '../../utils/isMobile';
 import clsx from 'clsx';
-import { useUserVotes } from '../../wrappers/nounToken';
+import { useNounTokenBalance, useUserVotes } from '../../wrappers/nounToken';
 import { Trans } from '@lingui/macro';
 import { ClockIcon } from '@heroicons/react/solid';
 import proposalStatusClasses from '../ProposalStatus/ProposalStatus.module.css';
@@ -17,6 +17,7 @@ import { SUPPORTED_LOCALE_TO_DAYSJS_LOCALE, SupportedLocale } from '../../i18n/l
 import React, { useState } from 'react';
 import DelegationModal from '../DelegationModal';
 import { i18n } from '@lingui/core';
+import { ethers } from 'ethers';
 
 dayjs.extend(relativeTime);
 
@@ -80,6 +81,10 @@ const Proposals = ({ proposals }: { proposals: Proposal[] }) => {
   };
 
   const hasNouns = account !== undefined && connectedAccountNounVotes > 0;
+  const hasNounBalance =
+    (useNounTokenBalance(
+      account !== null && account !== undefined ? account : ethers.constants.AddressZero,
+    ) ?? 0) > 0;
   return (
     <div className={classes.proposals}>
       {showDelegateModal && <DelegationModal onDismiss={() => setShowDelegateModal(false)} />}
@@ -98,14 +103,16 @@ const Proposals = ({ proposals }: { proposals: Proposal[] }) => {
               </Button>
             </div>
 
-            <div className={classes.delegateBtnWrapper}>
-              <Button
-                className={classes.changeDelegateBtn}
-                onClick={() => setShowDelegateModal(true)}
-              >
-                <Trans>Delegate</Trans>
-              </Button>
-            </div>
+            {hasNounBalance && (
+              <div className={classes.delegateBtnWrapper}>
+                <Button
+                  className={classes.changeDelegateBtn}
+                  onClick={() => setShowDelegateModal(true)}
+                >
+                  <Trans>Delegate</Trans>
+                </Button>
+              </div>
+            )}
           </div>
         ) : (
           <div className={clsx('d-flex', classes.nullStateSubmitProposalBtnWrapper)}>

--- a/packages/nouns-webapp/src/components/Proposals/index.tsx
+++ b/packages/nouns-webapp/src/components/Proposals/index.tsx
@@ -81,7 +81,7 @@ const Proposals = ({ proposals }: { proposals: Proposal[] }) => {
   };
 
   const hasNounVotes = account !== undefined && connectedAccountNounVotes > 0;
-  const hasNounBalance =
+  const hasNounBalance = 
     (useNounTokenBalance(
       account !== null && account !== undefined ? account : ethers.constants.AddressZero,
     ) ?? 0) > 0;
@@ -122,7 +122,7 @@ const Proposals = ({ proposals }: { proposals: Proposal[] }) => {
                 <Trans>Submit Proposal</Trans>
               </Button>
             </div>
-            {hasNounBalance && (
+            {!isMobile && hasNounBalance && (
               <div className={classes.delegateBtnWrapper}>
                 <Button
                   className={classes.changeDelegateBtn}
@@ -136,6 +136,16 @@ const Proposals = ({ proposals }: { proposals: Proposal[] }) => {
         )}
       </div>
       {isMobile && <div className={classes.nullStateCopy}>{nullStateCopy()}</div>}
+      {
+        isMobile && hasNounBalance &&  <div>
+        <Button
+          className={classes.changeDelegateBtn}
+          onClick={() => setShowDelegateModal(true)}
+        >
+          <Trans>Delegate</Trans>
+        </Button>
+      </div>
+      }
       {proposals?.length ? (
         proposals
           .slice(0)

--- a/packages/nouns-webapp/src/components/Proposals/index.tsx
+++ b/packages/nouns-webapp/src/components/Proposals/index.tsx
@@ -80,7 +80,7 @@ const Proposals = ({ proposals }: { proposals: Proposal[] }) => {
     return <Trans>Connect wallet to make a proposal.</Trans>;
   };
 
-  const hasNouns = account !== undefined && connectedAccountNounVotes > 0;
+  const hasNounVotes = account !== undefined && connectedAccountNounVotes > 0;
   const hasNounBalance =
     (useNounTokenBalance(
       account !== null && account !== undefined ? account : ethers.constants.AddressZero,
@@ -88,11 +88,11 @@ const Proposals = ({ proposals }: { proposals: Proposal[] }) => {
   return (
     <div className={classes.proposals}>
       {showDelegateModal && <DelegationModal onDismiss={() => setShowDelegateModal(false)} />}
-      <div className={clsx(classes.headerWrapper, !hasNouns ? classes.forceFlexRow : '')}>
+      <div className={clsx(classes.headerWrapper, !hasNounVotes ? classes.forceFlexRow : '')}>
         <h3 className={classes.heading}>
           <Trans>Proposals</Trans>
         </h3>
-        {hasNouns ? (
+        {hasNounVotes ? (
           <div className={classes.nounInWalletBtnWrapper}>
             <div className={classes.submitProposalButtonWrapper}>
               <Button
@@ -122,6 +122,16 @@ const Proposals = ({ proposals }: { proposals: Proposal[] }) => {
                 <Trans>Submit Proposal</Trans>
               </Button>
             </div>
+            {hasNounBalance && (
+              <div className={classes.delegateBtnWrapper}>
+                <Button
+                  className={classes.changeDelegateBtn}
+                  onClick={() => setShowDelegateModal(true)}
+                >
+                  <Trans>Delegate</Trans>
+                </Button>
+              </div>
+            )}
           </div>
         )}
       </div>


### PR DESCRIPTION
Fix bug flagged by poap that an account with a Noun balance but all votes delegated will not see the delegation button

## Testing done

Tested the following cases on desktop and mobile and confirm they rendered as expected:

- no votes, no Noun
- no zero votes, no Nouns
- no votes, non zero Nouns,
- non zero votes, non zero Nouns