### PR TITLE
Fix noun balance wallet not connected issue

### DIFF
--- a/packages/nouns-webapp/src/components/Proposals/index.tsx
+++ b/packages/nouns-webapp/src/components/Proposals/index.tsx
@@ -6,7 +6,7 @@ import { useHistory } from 'react-router-dom';
 import { useBlockNumber, useEthers } from '@usedapp/core';
 import { isMobileScreen } from '../../utils/isMobile';
 import clsx from 'clsx';
-import { useNounTokenBalance, useUserVotes } from '../../wrappers/nounToken';
+import { useUserNounTokenBalance, useUserVotes } from '../../wrappers/nounToken';
 import { Trans } from '@lingui/macro';
 import { ClockIcon } from '@heroicons/react/solid';
 import proposalStatusClasses from '../ProposalStatus/ProposalStatus.module.css';
@@ -17,7 +17,6 @@ import { SUPPORTED_LOCALE_TO_DAYSJS_LOCALE, SupportedLocale } from '../../i18n/l
 import React, { useState } from 'react';
 import DelegationModal from '../DelegationModal';
 import { i18n } from '@lingui/core';
-import { ethers } from 'ethers';
 import en from 'dayjs/locale/en';
 
 dayjs.extend(relativeTime);
@@ -88,9 +87,7 @@ const Proposals = ({ proposals }: { proposals: Proposal[] }) => {
 
   const hasNounVotes = account !== undefined && connectedAccountNounVotes > 0;
   const hasNounBalance =
-    (useNounTokenBalance(
-      account !== null && account !== undefined ? account : ethers.constants.AddressZero,
-    ) ?? 0) > 0;
+    (useUserNounTokenBalance() ?? 0) > 0;
   return (
     <div className={classes.proposals}>
       {showDelegateModal && <DelegationModal onDismiss={() => setShowDelegateModal(false)} />}

--- a/packages/nouns-webapp/src/wrappers/nounToken.ts
+++ b/packages/nouns-webapp/src/wrappers/nounToken.ts
@@ -173,3 +173,16 @@ export const useNounTokenBalance = (address: string): number | undefined => {
     }) || [];
   return tokenBalance?.toNumber();
 };
+
+export const useUserNounTokenBalance = (): number | undefined => {
+  const { account } = useEthers();
+
+  const [tokenBalance] =
+    useContractCall<[EthersBN]>({
+      abi,
+      address: config.addresses.nounsToken,
+      method: 'balanceOf',
+      args: [account],
+    }) || [];
+  return tokenBalance?.toNumber();
+};


### PR DESCRIPTION
(this issue was not experienced by prod users, was found on stage)

if wallet not connected previous fix for delegate modal trigger condition caused props not to load. 