### PR TITLE
Fix wrong 'body' prefix for a few accessories

### DIFF
--- a/packages/nouns-assets/src/image-data.json
+++ b/packages/nouns-assets/src/image-data.json
@@ -901,19 +901,19 @@
         "data": "0x0018121b0e060e024c020e064c"
       },
       {
-        "filename": "body-bege",
+        "filename": "accessory-bege",
         "data": "0x0015171f093a0101000d0101000d0101000d0101000d0101000d0101000d0101000b01"
       },
       {
-        "filename": "body-gray-scale-1",
+        "filename": "accessory-gray-scale-1",
         "data": "0x0015171f093a0c01000d0c01000d0c01000d0c01000d0c01000d0c01000d0c01000b0c"
       },
       {
-        "filename": "body-gray-scale-9",
+        "filename": "accessory-gray-scale-9",
         "data": "0x0015171f093a0f01000d0f01000d0f01000d0f01000d0f01000d0f01000d0f01000b0f"
       },
       {
-        "filename": "body-ice-cold",
+        "filename": "accessory-ice-cold",
         "data": "0x0015171f093a0601000d0601000d0601000d0601000d0601000d0601000d0601000b06"
       }
     ],


### PR DESCRIPTION
Calling `getNounData` with the current noun (382) seed returns 2 so-called 'body' parts.

```
[
    {
        "filename": "body-purple",
        "data": "0x0015171f090e170e170e170e17021701000b17021701000b17021701000b17021701000b17021701000b17021701000b17021701000b17"
    },
    {
        "filename": "body-gray-scale-1",
        "data": "0x0015171f090e0b0e0b0e0b0e0b020b01000b0b020b01000b0b020b01000b0b020b01000b0b020b01000b0b020b01000b0b020b01000b0b"
    },
    {
        "filename": "head-crab",
        "data": "0x00021b1405040004130600041304000200071304000713020001000913020009130100031302b30c0002b303130a1302000a130913040009130213010005130600051301000213021307000123020001230700021302130100101301000213021301001013010002131613161316130300101303000300101303000300101303000300061304b306130300030010130300030010130300"
    },
    {
        "filename": "glasses-square-orange",
        "data": "0x000b17100703000614010006140300011402010223011401000114020102230114041402010223031402010223011401140200011402010223011401000114020102230114011402000114020102230114010001140201022301140300061401000614"
    }
]
```

`body-gray-scale-1` should read `accessory-gray-scale-1` instead.