### PR TITLE
Fix delegate nouns represented error

### DIFF
--- a/packages/nouns-subgraph/src/nouns-erc-721.ts
+++ b/packages/nouns-subgraph/src/nouns-erc-721.ts
@@ -135,7 +135,7 @@ export function handleTransfer(event: Transfer): void {
     governance.save();
   }
 
-  let toHolderDelegate = getOrCreateDelegate(toHolder.id);
+  let toHolderDelegate = getOrCreateDelegate(toHolder.delegate ? toHolder.delegate: toHolder.id);
   let toHolderNounsRepresented = toHolderDelegate.nounsRepresented; // Re-assignment required to update array
   toHolderNounsRepresented.push(transferredNounId);
   toHolderDelegate.nounsRepresented = toHolderNounsRepresented;


### PR DESCRIPTION
# TLDR

Fixes issue where `nounsRepresented` for delegates was getting incorrectly updated in the event of a Noun transfer. 

*Note this is specifically for the list of represented Nouns, the delegate vote count was correct*

# Context

Some users (for example, 4156) mentioned that the vote counts currently displayed on the prop page hover cards are not correct. In particular, 4156 noted that the card said he had 4 votes for prop 107 when in fact he had 14. I was grabbing these values directly from the subgraph and thus suspected an error there.

I traced through a bunch of Noun transfer and delegation txns and I believe the issue is that when Nouns were transferred, if those Nouns' votes were delegated the graph was updating the vote count but not the list of represented Nouns.


# Testing done

I spot checked the majority of delegate vote counts for prop 107 and confirmed they matched Tally (in particular, confirmed that default self delegation still worked and that the two cases that were reported by 4156 and the Nouncil matched the expected vote count).
