### PR TITLE
Add Delegation and Transfer events to subgraph 

### DIFF
--- a/packages/nouns-subgraph/schema.graphql
+++ b/packages/nouns-subgraph/schema.graphql
@@ -1,3 +1,46 @@
+type DelegationEvent @entity {
+  "The txn hash of this event + nounId"
+  id: ID!
+
+  "The Noun being delegated"
+  noun: Noun!
+
+  "Previous delegate address"
+  previousDelegate: Delegate! 
+
+  "New delegate address"
+  newDelegate: Delegate! 
+
+ "Block number of the bid"
+  blockNumber: BigInt!
+
+  "The timestamp of the block the bid is in"
+  blockTimestamp: BigInt!
+
+}
+
+
+type TransferEvent @entity {
+  "The txn hash of this event"
+  id: ID!
+
+  "The Noun being transfered"
+  noun: Noun!
+
+  "Previous holder address"
+  previousHolder: Account!
+
+  "New holder address"
+  newHolder: Account!
+
+  "Block number of the bid"
+  blockNumber: BigInt!
+
+  "The timestamp of the block the bid is in"
+  blockTimestamp: BigInt!
+}
+
+
 type Seed @entity {
   "The Noun's ERC721 token id"
   id: ID!

--- a/packages/nouns-subgraph/schema.graphql
+++ b/packages/nouns-subgraph/schema.graphql
@@ -273,6 +273,9 @@ type Vote @entity {
 
   "Proposal that is being voted on"
   proposal: Proposal!
+
+  "Block number of vote"
+  blockNumber: BigInt!
 }
 
 type Governance @entity {

--- a/packages/nouns-subgraph/schema.graphql
+++ b/packages/nouns-subgraph/schema.graphql
@@ -14,7 +14,7 @@ type DelegationEvent @entity {
  "Block number of the bid"
   blockNumber: BigInt!
 
-  "The timestamp of the block the bid is in"
+  "The timestamp of the block the event is in"
   blockTimestamp: BigInt!
 
 }
@@ -36,7 +36,7 @@ type TransferEvent @entity {
   "Block number of the bid"
   blockNumber: BigInt!
 
-  "The timestamp of the block the bid is in"
+  "The timestamp of the block the event is in"
   blockTimestamp: BigInt!
 }
 

--- a/packages/nouns-subgraph/schema.graphql
+++ b/packages/nouns-subgraph/schema.graphql
@@ -11,7 +11,7 @@ type DelegationEvent @entity {
   "New delegate address"
   newDelegate: Delegate! 
 
- "Block number of the bid"
+ "Block number of the event"
   blockNumber: BigInt!
 
   "The timestamp of the block the event is in"
@@ -33,7 +33,7 @@ type TransferEvent @entity {
   "New holder address"
   newHolder: Account!
 
-  "Block number of the bid"
+  "Block number of the event"
   blockNumber: BigInt!
 
   "The timestamp of the block the event is in"

--- a/packages/nouns-subgraph/src/nouns-dao.ts
+++ b/packages/nouns-subgraph/src/nouns-dao.ts
@@ -129,6 +129,7 @@ export function handleVoteCast(event: VoteCast): void {
   vote.support = event.params.support == 1;
   vote.supportDetailed = event.params.support;
   vote.nouns = voter.nounsRepresented;
+  vote.blockNumber = event.block.number;
 
   if (event.params.reason != '') {
     vote.reason = event.params.reason;

--- a/packages/nouns-subgraph/src/nouns-erc-721.ts
+++ b/packages/nouns-subgraph/src/nouns-erc-721.ts
@@ -5,7 +5,7 @@ import {
   NounCreated,
   Transfer,
 } from './types/NounsToken/NounsToken';
-import { Noun, Seed } from './types/schema';
+import { Noun, Seed, DelegationEvent, TransferEvent } from './types/schema';
 import { BIGINT_ONE, BIGINT_ZERO, ZERO_ADDRESS } from './utils/constants';
 import { getGovernanceEntity, getOrCreateDelegate, getOrCreateAccount } from './utils/helpers';
 
@@ -33,7 +33,9 @@ export function handleNounCreated(event: NounCreated): void {
   noun.save();
 }
 
-let accountNouns: string[] = []; // Use WebAssembly global due to lack of closure support
+// Use WebAssembly global due to lack of closure support
+let accountNouns: string[] = [];
+
 export function handleDelegateChanged(event: DelegateChanged): void {
   let tokenHolder = getOrCreateAccount(event.params.delegator.toHexString());
   let previousDelegate = getOrCreateDelegate(event.params.fromDelegate.toHexString());
@@ -57,6 +59,25 @@ export function handleDelegateChanged(event: DelegateChanged): void {
   newDelegate.nounsRepresented = newNounsRepresented;
   previousDelegate.save();
   newDelegate.save();
+
+  if (accountNouns.includes('309')) {
+    log.error('New delegate {}', [newDelegate.id.toString()]);
+  }
+
+  // Log a transfer event for each Noun
+  for (let i = 0; i < accountNouns.length; i++) {
+    let delegateChangedEvent = new DelegationEvent(
+      event.transaction.hash.toHexString() + '_' + accountNouns[i],
+    );
+    delegateChangedEvent.blockNumber = event.block.number;
+    delegateChangedEvent.blockTimestamp = event.block.timestamp;
+    delegateChangedEvent.noun = accountNouns[i];
+    delegateChangedEvent.previousDelegate = previousDelegate.id
+      ? previousDelegate.id
+      : tokenHolder.id;
+    delegateChangedEvent.newDelegate = newDelegate.id ? newDelegate.id : tokenHolder.id;
+    delegateChangedEvent.save();
+  }
 }
 
 export function handleDelegateVotesChanged(event: DelegateVotesChanged): void {
@@ -85,6 +106,14 @@ export function handleTransfer(event: Transfer): void {
   let toHolder = getOrCreateAccount(event.params.to.toHexString());
   let governance = getGovernanceEntity();
   transferredNounId = event.params.tokenId.toString();
+
+  let transferEvent = new TransferEvent(event.transaction.hash.toHexString());
+  transferEvent.blockNumber = event.block.number;
+  transferEvent.blockTimestamp = event.block.timestamp;
+  transferEvent.noun = event.params.tokenId.toString();
+  transferEvent.previousHolder = fromHolder.id.toString();
+  transferEvent.newHolder = toHolder.id.toString();
+  transferEvent.save();
 
   // fromHolder
   if (event.params.from.toHexString() == ZERO_ADDRESS) {
@@ -134,6 +163,20 @@ export function handleTransfer(event: Transfer): void {
     governance.totalTokenHolders = governance.totalTokenHolders - BIGINT_ONE;
     governance.save();
   }
+
+  let delegateChangedEvent = new DelegationEvent(
+    event.transaction.hash.toHexString() + '_' + event.params.tokenId.toString(),
+  );
+  delegateChangedEvent.blockNumber = event.block.number;
+  delegateChangedEvent.blockTimestamp = event.block.timestamp;
+  delegateChangedEvent.noun = event.params.tokenId.toString();
+  delegateChangedEvent.previousDelegate = fromHolder.delegate
+    ? fromHolder.delegate.toString()
+    : fromHolder.id.toString();
+  delegateChangedEvent.newDelegate = toHolder.delegate
+    ? toHolder.delegate.toString()
+    : toHolder.id.toString();
+  delegateChangedEvent.save();
 
   let toHolderDelegate = getOrCreateDelegate(toHolder.id);
   let toHolderNounsRepresented = toHolderDelegate.nounsRepresented; // Re-assignment required to update array

--- a/packages/nouns-subgraph/src/nouns-erc-721.ts
+++ b/packages/nouns-subgraph/src/nouns-erc-721.ts
@@ -60,10 +60,6 @@ export function handleDelegateChanged(event: DelegateChanged): void {
   previousDelegate.save();
   newDelegate.save();
 
-  if (accountNouns.includes('309')) {
-    log.error('New delegate {}', [newDelegate.id.toString()]);
-  }
-
   // Log a transfer event for each Noun
   for (let i = 0; i < accountNouns.length; i++) {
     let delegateChangedEvent = new DelegationEvent(

--- a/packages/nouns-subgraph/src/nouns-erc-721.ts
+++ b/packages/nouns-subgraph/src/nouns-erc-721.ts
@@ -178,7 +178,7 @@ export function handleTransfer(event: Transfer): void {
     : toHolder.id.toString();
   delegateChangedEvent.save();
 
-  let toHolderDelegate = getOrCreateDelegate(toHolder.id);
+  let toHolderDelegate = getOrCreateDelegate(toHolder.delegate ? toHolder.delegate: toHolder.id);
   let toHolderNounsRepresented = toHolderDelegate.nounsRepresented; // Re-assignment required to update array
   toHolderNounsRepresented.push(transferredNounId);
   toHolderDelegate.nounsRepresented = toHolderNounsRepresented;

--- a/packages/nouns-subgraph/src/nouns-erc-721.ts
+++ b/packages/nouns-subgraph/src/nouns-erc-721.ts
@@ -107,7 +107,8 @@ export function handleTransfer(event: Transfer): void {
   let governance = getGovernanceEntity();
   transferredNounId = event.params.tokenId.toString();
 
-  let transferEvent = new TransferEvent(event.transaction.hash.toHexString());
+
+  let transferEvent = new TransferEvent(event.transaction.hash.toHexString() + "_" + transferredNounId);
   transferEvent.blockNumber = event.block.number;
   transferEvent.blockTimestamp = event.block.timestamp;
   transferEvent.noun = event.params.tokenId.toString();


### PR DESCRIPTION
## TLDR

This PR does 3 things:
1. Adds `TransferEvent` entity to subgraph (+ corresponding indexing code)
2. Adds `DelegationEvent` entity to subgraph ( + corresponding indexing code)
3. Adds `blockNumber` to existing `Vote` entity (+ corresponding indexing code)

## Testing done

I have been using a clone of the `nouns-subgraph` running this code on #525 for about a week now without issues