### PR TITLE
[Bug fix] Refactor TightStackedCircleNouns to fix delegate view intermittent crash

### DIFF
--- a/packages/nouns-webapp/src/components/Proposals/index.tsx
+++ b/packages/nouns-webapp/src/components/Proposals/index.tsx
@@ -86,8 +86,7 @@ const Proposals = ({ proposals }: { proposals: Proposal[] }) => {
   };
 
   const hasNounVotes = account !== undefined && connectedAccountNounVotes > 0;
-  const hasNounBalance =
-    (useUserNounTokenBalance() ?? 0) > 0;
+  const hasNounBalance = (useUserNounTokenBalance() ?? 0) > 0;
   return (
     <div className={classes.proposals}>
       {showDelegateModal && <DelegationModal onDismiss={() => setShowDelegateModal(false)} />}

--- a/packages/nouns-webapp/src/components/TightStackedCircleNoun/index.tsx
+++ b/packages/nouns-webapp/src/components/TightStackedCircleNoun/index.tsx
@@ -1,0 +1,53 @@
+import { useNounSeed } from '../../wrappers/nounToken';
+import { BigNumber } from 'ethers';
+import { getNoun } from '../StandaloneNoun';
+import { LoadingNoun } from '../Noun';
+
+interface TightStackedCircleNounProps {
+  nounId: number;
+  index: number;
+  square: number;
+  shift: number;
+}
+
+const TightStackedCircleNoun: React.FC<TightStackedCircleNounProps> = props => {
+  const { nounId, index, square, shift } = props;
+  const seed = useNounSeed(BigNumber.from(nounId));
+
+  if (!seed) {
+      return <LoadingNoun/>;
+  }
+
+  const nounData = getNoun(BigNumber.from(nounId), seed);
+  const image = nounData.image;
+
+  return (
+    <g key={index}>
+      <clipPath id={`clipCircleNoun${nounId}`}>
+        <circle
+          id={`${nounId}`}
+          r="20"
+          cx={28 + index * shift}
+          cy={square - 21 - index * shift}
+          style={{
+            fill: 'none',
+            stroke: 'white',
+            strokeWidth: '2',
+          }}
+        />
+      </clipPath>
+
+      <use xlinkHref={`#${nounId}`} />
+      <image
+        clipPath={`url(#clipCircleNoun${nounId})`}
+        x={8 + index * shift}
+        y={14 - index * shift}
+        width="40"
+        height="40"
+        href={image}
+      ></image>
+    </g>
+  );
+};
+
+export default TightStackedCircleNoun;

--- a/packages/nouns-webapp/src/components/TightStackedCircleNouns/index.tsx
+++ b/packages/nouns-webapp/src/components/TightStackedCircleNouns/index.tsx
@@ -1,6 +1,5 @@
-import { getNoun } from '../StandaloneNoun';
-import { BigNumber } from 'ethers';
-import { useNounSeeds } from '../../wrappers/nounToken';
+import React from 'react';
+import TightStackedCircleNoun from '../TightStackedCircleNoun';
 
 interface StackedCircleNounsProps {
   nounIds: Array<number>;
@@ -11,50 +10,16 @@ const MAX_NOUNS_PER_STACK = 3;
 const TightStackedCircleNouns: React.FC<StackedCircleNounsProps> = props => {
   const { nounIds } = props;
 
-  const seeds = useNounSeeds();
-
-  const svgs = seeds
-    ? nounIds.slice(0, MAX_NOUNS_PER_STACK).map((nounId: number) => {
-        const nounData = getNoun(BigNumber.from(nounId), seeds[nounId]);
-        return nounData.image;
-      })
-    : [];
-
   const shift = 3;
 
   const square = 55;
 
   return (
     <svg width={square} height={square}>
-      {svgs
-        .map((dataURI: string, i: number) => {
-          return (
-            <g key={i}>
-              <clipPath id={`clipCircleNoun${nounIds[i]}`}>
-                <circle
-                  id={`${nounIds[i]}`}
-                  r="20"
-                  cx={28 + i * shift}
-                  cy={square - 21 - i * shift}
-                  style={{
-                    fill: 'none',
-                    stroke: 'white',
-                    strokeWidth: '2',
-                  }}
-                />
-              </clipPath>
-
-              <use xlinkHref={`#${nounIds[i]}`} />
-              <image
-                clipPath={`url(#clipCircleNoun${nounIds[i]})`}
-                x={8 + i * shift}
-                y={14 - i * shift}
-                width="40"
-                height="40"
-                href={dataURI}
-              ></image>
-            </g>
-          );
+      {nounIds
+        .slice(0, MAX_NOUNS_PER_STACK)
+        .map((nounId: number, i: number) => {
+          return <TightStackedCircleNoun nounId={nounId} index={i} square={square} shift={shift} />;
         })
         .reverse()}
     </svg>

--- a/packages/nouns-webapp/src/wrappers/nounToken.ts
+++ b/packages/nouns-webapp/src/wrappers/nounToken.ts
@@ -66,7 +66,7 @@ const seedArrayToObject = (seeds: (INounSeed & { id: string })[]) => {
   }, {});
 };
 
-export const useNounSeeds = () => {
+const useNounSeeds = () => {
   const cache = localStorage.getItem(seedCacheKey);
   const cachedSeeds = cache ? JSON.parse(cache) : undefined;
   const { data } = useQuery(seedsQuery(), {


### PR DESCRIPTION
# TLDLR
Fixed bug reported by raz and 9999 that the delegate view would sometimes crash.

### What happened

If the seed cache was stale, because the `TightStackedCircleNouns` was directly indexing into the array from `useNounSeeeds` an undefined value would be returned if a `nounId` was not in the cache. This would then result in an error when we tried to render that undefined value into a Noun image.

### How is it fixed

Refactor the `TightStackedCircleNouns` component to use the `useNounSeed` method which has logic to fallback to a chain call in the case of a stale seed cache.

# Testing done

Manually set a seed cache value (in local storage) that would consistently produce crashes in the delegate view. Confirmed that with this change this no longer occurs.

**Cache value that will cause the error  if you load prop 122:**
https://pastebin.com/XNCgd3A4