### PR TITLE
Fix Playground PNG Image Rendering

### DIFF
--- a/packages/nouns-webapp/src/locales/en-US.po
+++ b/packages/nouns-webapp/src/locales/en-US.po
@@ -1134,8 +1134,8 @@ msgid "Your <0>{availableVotes}</0> votes have been delegated to a new account."
 msgstr "Your <0>{availableVotes}</0> votes have been delegated to a new account."
 
 #: src/components/Documentation/index.tsx
-msgid "accessories (137)"
-msgstr "accessories (137)"
+msgid "accessories (140)"
+msgstr "accessories (140)"
 
 #: src/components/AuctionTimer/index.tsx
 msgid "at"
@@ -1154,16 +1154,16 @@ msgid "bodies (30)"
 msgstr "bodies (30)"
 
 #: src/components/Documentation/index.tsx
-msgid "glasses (21)"
-msgstr "glasses (21)"
+msgid "glasses (23)"
+msgstr "glasses (23)"
 
 #: src/components/AuctionTimer/index.tsx
 msgid "h"
 msgstr "h"
 
 #: src/components/Documentation/index.tsx
-msgid "heads (234)"
-msgstr "heads (234)"
+msgid "heads (242)"
+msgstr "heads (242)"
 
 #: src/components/AuctionTimer/index.tsx
 msgid "m"

--- a/packages/nouns-webapp/src/locales/ja-JP.po
+++ b/packages/nouns-webapp/src/locales/ja-JP.po
@@ -1135,8 +1135,8 @@ msgid "Your <0>{availableVotes}</0> votes have been delegated to a new account."
 msgstr "あなたの<0>{availableVotes}</0>票が新しいアカウントに委任されました"
 
 #: src/components/Documentation/index.tsx
-msgid "accessories (137)"
-msgstr "付属品(137)"
+msgid "accessories (140)"
+msgstr "付属品(140)"
 
 #: src/components/AuctionTimer/index.tsx
 msgid "at"
@@ -1155,16 +1155,16 @@ msgid "bodies (30)"
 msgstr "体 (30)"
 
 #: src/components/Documentation/index.tsx
-msgid "glasses (21)"
-msgstr "メガネ (21)"
+msgid "glasses (23)"
+msgstr "メガネ (23)"
 
 #: src/components/AuctionTimer/index.tsx
 msgid "h"
 msgstr "時間"
 
 #: src/components/Documentation/index.tsx
-msgid "heads (234)"
-msgstr "頭 (234)"
+msgid "heads (242)"
+msgstr "頭 (242)"
 
 #: src/components/AuctionTimer/index.tsx
 msgid "m"

--- a/packages/nouns-webapp/src/locales/pseudo.po
+++ b/packages/nouns-webapp/src/locales/pseudo.po
@@ -1134,7 +1134,7 @@ msgid "Your <0>{availableVotes}</0> votes have been delegated to a new account."
 msgstr ""
 
 #: src/components/Documentation/index.tsx
-msgid "accessories (137)"
+msgid "accessories (140)"
 msgstr ""
 
 #: src/components/AuctionTimer/index.tsx
@@ -1154,7 +1154,7 @@ msgid "bodies (30)"
 msgstr ""
 
 #: src/components/Documentation/index.tsx
-msgid "glasses (21)"
+msgid "glasses (23)"
 msgstr ""
 
 #: src/components/AuctionTimer/index.tsx
@@ -1162,7 +1162,7 @@ msgid "h"
 msgstr ""
 
 #: src/components/Documentation/index.tsx
-msgid "heads (234)"
+msgid "heads (242)"
 msgstr ""
 
 #: src/components/AuctionTimer/index.tsx


### PR DESCRIPTION
Fix an issue that caused ugly gaps between pixels when rasterizing and downloading Noun images from the playground.