### PR TITLE
fix delegateBySig to not allow delegating to address(0)

### DIFF
--- a/packages/nouns-contracts/contracts/base/ERC721Checkpointable.sol
+++ b/packages/nouns-contracts/contracts/base/ERC721Checkpointable.sol
@@ -140,6 +140,9 @@ abstract contract ERC721Checkpointable is ERC721Enumerable {
         require(signatory != address(0), 'ERC721Checkpointable::delegateBySig: invalid signature');
         require(nonce == nonces[signatory]++, 'ERC721Checkpointable::delegateBySig: invalid nonce');
         require(block.timestamp <= expiry, 'ERC721Checkpointable::delegateBySig: signature expired');
+
+        /// @notice delegating to address(0) self-delegates, similar to delegate(address)
+        if (delegatee == address(0)) delegatee = signatory;
         return _delegate(signatory, delegatee);
     }
 


### PR DESCRIPTION
instead when address(0) is the delegatee it does self delegation, similar to the implementation in `delegate(address)`

this is a fix following c4 issue: https://github.com/code-423n4/2022-08-nounsdao-findings/issues/157