### PR TITLE
Delegation Modal "deep linking"

### DIFF
--- a/packages/nouns-webapp/src/App.tsx
+++ b/packages/nouns-webapp/src/App.tsx
@@ -22,6 +22,7 @@ import { CHAIN_ID } from './config';
 import relativeTime from 'dayjs/plugin/relativeTime';
 import { AvatarProvider } from '@davatar/react';
 import dayjs from 'dayjs';
+import DelegatePage from './pages/DelegatePage';
 
 function App() {
   const { account, chainId, library } = useEthers();
@@ -64,6 +65,7 @@ function App() {
             <Route exact path="/vote" component={GovernancePage} />
             <Route exact path="/vote/:id" component={VotePage} />
             <Route exact path="/playground" component={Playground} />
+            <Route exact path="/delegate" component={DelegatePage} />
             <Route component={NotFoundPage} />
           </Switch>
           <Footer />

--- a/packages/nouns-webapp/src/components/ChangeDelegatePannel/ChangeDelegatePannel.module.css
+++ b/packages/nouns-webapp/src/components/ChangeDelegatePannel/ChangeDelegatePannel.module.css
@@ -16,6 +16,13 @@
   transition: all 0.2s ease-in-out;
 }
 
+.delegteDeepLinkSpinner {
+  display: flex;
+  justify-content: center;
+  margin-top: 1rem;
+  margin-bottom: 1rem;
+}
+
 .delegateInput:focus {
   box-shadow: none !important;
 }

--- a/packages/nouns-webapp/src/components/DelegationModal/DelegationModal.module.css
+++ b/packages/nouns-webapp/src/components/DelegationModal/DelegationModal.module.css
@@ -4,7 +4,7 @@
   left: 0;
   width: 100%;
   height: 100%;
-  z-index: 10;
+  z-index: 60;
   background: rgba(75, 75, 75, 0.5);
   backdrop-filter: blur(24px);
 }

--- a/packages/nouns-webapp/src/components/DelegationModal/index.tsx
+++ b/packages/nouns-webapp/src/components/DelegationModal/index.tsx
@@ -11,10 +11,11 @@ export const Backdrop: React.FC<{ onDismiss: () => void }> = props => {
 
 const DelegationModalOverlay: React.FC<{
   onDismiss: () => void;
+  delegateTo?: string;
 }> = props => {
-  const { onDismiss } = props;
+  const { onDismiss, delegateTo } = props;
 
-  const [isChangingDelegation, setIsChangingDelegation] = useState(false);
+  const [isChangingDelegation, setIsChangingDelegation] = useState(delegateTo !== undefined);
 
   return (
     <>
@@ -26,7 +27,7 @@ const DelegationModalOverlay: React.FC<{
 
       <div className={classes.modal}>
         {isChangingDelegation ? (
-          <ChangeDelegatePannel onDismiss={onDismiss} />
+          <ChangeDelegatePannel onDismiss={onDismiss} delegateTo={delegateTo} />
         ) : (
           <CurrentDelegatePannel
             onPrimaryBtnClick={() => setIsChangingDelegation(true)}
@@ -40,8 +41,9 @@ const DelegationModalOverlay: React.FC<{
 
 const DelegationModal: React.FC<{
   onDismiss: () => void;
+  delegateTo?: string;
 }> = props => {
-  const { onDismiss } = props;
+  const { onDismiss, delegateTo } = props;
   return (
     <>
       {ReactDOM.createPortal(
@@ -49,7 +51,7 @@ const DelegationModal: React.FC<{
         document.getElementById('backdrop-root')!,
       )}
       {ReactDOM.createPortal(
-        <DelegationModalOverlay onDismiss={onDismiss} />,
+        <DelegationModalOverlay onDismiss={onDismiss} delegateTo={delegateTo} />,
         document.getElementById('overlay-root')!,
       )}
     </>

--- a/packages/nouns-webapp/src/locales/en-US.po
+++ b/packages/nouns-webapp/src/locales/en-US.po
@@ -492,6 +492,9 @@ msgid "Help mint the next Noun"
 msgstr "Help mint the next Noun"
 
 #: src/components/profileEvent/event/DesktopTransferEvent/index.tsx
+msgid "Holder changed from <0><1/></0> to <2><3/></2>"
+msgstr "Holder changed from <0><1/></0> to <2><3/></2>"
+
 #: src/components/profileEvent/event/MobileTransferEvent/index.tsx
 msgid "Holder changed from<0><1/></0> to <2><3/></2>"
 msgstr "Holder changed from<0><1/></0> to <2><3/></2>"

--- a/packages/nouns-webapp/src/locales/ja-JP.po
+++ b/packages/nouns-webapp/src/locales/ja-JP.po
@@ -497,6 +497,9 @@ msgid "Help mint the next Noun"
 msgstr "次にミントされるNounの投票をしてください"
 
 #: src/components/profileEvent/event/DesktopTransferEvent/index.tsx
+msgid "Holder changed from <0><1/></0> to <2><3/></2>"
+msgstr ""
+
 #: src/components/profileEvent/event/MobileTransferEvent/index.tsx
 msgid "Holder changed from<0><1/></0> to <2><3/></2>"
 msgstr ""

--- a/packages/nouns-webapp/src/locales/pseudo.po
+++ b/packages/nouns-webapp/src/locales/pseudo.po
@@ -492,6 +492,9 @@ msgid "Help mint the next Noun"
 msgstr ""
 
 #: src/components/profileEvent/event/DesktopTransferEvent/index.tsx
+msgid "Holder changed from <0><1/></0> to <2><3/></2>"
+msgstr ""
+
 #: src/components/profileEvent/event/MobileTransferEvent/index.tsx
 msgid "Holder changed from<0><1/></0> to <2><3/></2>"
 msgstr ""

--- a/packages/nouns-webapp/src/pages/DelegatePage/index.tsx
+++ b/packages/nouns-webapp/src/pages/DelegatePage/index.tsx
@@ -8,6 +8,12 @@ const DelegatePage = () => {
 
   const history = useHistory();
 
+  if (!delegateTo || delegateTo.length === 0) {
+    return <>
+      <DelegationModal onDismiss={() => history.push('/vote')} />
+    </>
+  }
+
   return (
     <>
       <DelegationModal onDismiss={() => history.push('/vote')} delegateTo={delegateTo} />

--- a/packages/nouns-webapp/src/pages/DelegatePage/index.tsx
+++ b/packages/nouns-webapp/src/pages/DelegatePage/index.tsx
@@ -1,0 +1,18 @@
+import { useHistory, useLocation } from 'react-router-dom';
+import DelegationModal from '../../components/DelegationModal';
+import { getAddressFromQueryParams } from '../../utils/getAddressFromQueryParams';
+
+const DelegatePage = () => {
+  const { search } = useLocation();
+  const delegateTo = getAddressFromQueryParams('to', search);
+
+  const history = useHistory();
+
+  return (
+    <>
+      <DelegationModal onDismiss={() => history.push('/vote')} delegateTo={delegateTo} />
+    </>
+  );
+};
+
+export default DelegatePage;

--- a/packages/nouns-webapp/src/utils/getAddressFromQueryParams.ts
+++ b/packages/nouns-webapp/src/utils/getAddressFromQueryParams.ts
@@ -1,0 +1,30 @@
+import { ethers } from 'ethers';
+
+/**
+ * Get address from query param
+ *
+ * @param paramName query param name i.e. for the URL nouns.wtf/delegate?to=0xabv... to would be the paramName
+ * @param useLocationResult string returned by react-router-v5 useLocation
+ */
+export const getAddressFromQueryParams = (
+  paramName: string,
+  useLocationResult: string,
+): string | undefined => {
+  console.log(useLocationResult);
+  const splitLocationResult = useLocationResult
+    .split('=')
+    .map((s: string) => s.replace('?', '').replace('&', ''));
+
+  const paramIndex = splitLocationResult.indexOf(paramName);
+  if (paramIndex < 0 || paramIndex === splitLocationResult.length - 1) {
+    return undefined;
+  }
+
+  const maybeAddress = splitLocationResult[paramIndex + 1];
+
+  if (maybeAddress.endsWith('.eth') || maybeAddress.endsWith(encodeURIComponent('.⌐◨-◨'))) {
+    return decodeURIComponent(maybeAddress);
+  }
+
+  return ethers.utils.isAddress(maybeAddress) ? maybeAddress : undefined;
+};


### PR DESCRIPTION
# TLDR

Allows pre-population of the delegation modal via linking to `nouns.wtf/delgate?to=<Address or ENS>`

for example `nouns.wtf/delegate?to=nouncil.eth` .

Upon modal close (either explicitly by the user or on successful delegation we redirect to the `/vote` page). 

**Note:** At this time, the delegation links do NOT support NNS


(note, this was originally part of a larger batch of governance changes I am working on but am prioritizing it because it will help the Agora team)

# Testing done

Tested with linking to both Addresses as well as ENS. Also confirmed that `/delegate` without a query param doesn't crash things (it just shows a blank delegation modal).

Also tested the full delegation flow on rinkeby. 
