### PR TITLE
Update average block time seconds

### DIFF
--- a/packages/nouns-webapp/src/components/Proposals/index.tsx
+++ b/packages/nouns-webapp/src/components/Proposals/index.tsx
@@ -22,7 +22,7 @@ import en from 'dayjs/locale/en';
 dayjs.extend(relativeTime);
 
 const getCountdownCopy = (proposal: Proposal, currentBlock: number, locale: SupportedLocale) => {
-  const AVERAGE_BLOCK_TIME_IN_SECS = 13;
+  const AVERAGE_BLOCK_TIME_IN_SECS = 12;
   const timestamp = Date.now();
   const startDate =
     proposal && timestamp && currentBlock

--- a/packages/nouns-webapp/src/components/Proposals/index.tsx
+++ b/packages/nouns-webapp/src/components/Proposals/index.tsx
@@ -18,11 +18,11 @@ import React, { useEffect, useState } from 'react';
 import DelegationModal from '../DelegationModal';
 import { i18n } from '@lingui/core';
 import en from 'dayjs/locale/en';
+import { AVERAGE_BLOCK_TIME_IN_SECS } from '../../utils/constants';
 
 dayjs.extend(relativeTime);
 
 const getCountdownCopy = (proposal: Proposal, currentBlock: number, locale: SupportedLocale) => {
-  const AVERAGE_BLOCK_TIME_IN_SECS = 12;
   const timestamp = Date.now();
   const startDate =
     proposal && timestamp && currentBlock

--- a/packages/nouns-webapp/src/pages/Vote/index.tsx
+++ b/packages/nouns-webapp/src/pages/Vote/index.tsx
@@ -33,12 +33,12 @@ import { getNounVotes } from '../../utils/getNounsVotes';
 import { Trans } from '@lingui/macro';
 import { i18n } from '@lingui/core';
 import { ReactNode } from 'react-markdown/lib/react-markdown';
+import { AVERAGE_BLOCK_TIME_IN_SECS } from '../../utils/constants';
 
 dayjs.extend(utc);
 dayjs.extend(timezone);
 dayjs.extend(advanced);
 
-const AVERAGE_BLOCK_TIME_IN_SECS = 12;
 
 const VotePage = ({
   match: {

--- a/packages/nouns-webapp/src/pages/Vote/index.tsx
+++ b/packages/nouns-webapp/src/pages/Vote/index.tsx
@@ -38,7 +38,7 @@ dayjs.extend(utc);
 dayjs.extend(timezone);
 dayjs.extend(advanced);
 
-const AVERAGE_BLOCK_TIME_IN_SECS = 13;
+const AVERAGE_BLOCK_TIME_IN_SECS = 12;
 
 const VotePage = ({
   match: {

--- a/packages/nouns-webapp/src/utils/constants.ts
+++ b/packages/nouns-webapp/src/utils/constants.ts
@@ -1,0 +1,1 @@
+export const AVERAGE_BLOCK_TIME_IN_SECS = 12;


### PR DESCRIPTION
Update `AVERAGE_BLOCK_TIME_SCONDS` (used for approximately mapping block time diffs to seconds diffs) from 13 to 12 post mereg. 