### PR TITLE
Link to soli twitter from landing page

### DIFF
--- a/packages/nouns-webapp/src/components/Documentation/index.tsx
+++ b/packages/nouns-webapp/src/components/Documentation/index.tsx
@@ -316,7 +316,13 @@ const Documentation = () => {
                 <li>
                   <Link text="@punk4464" url="https://twitter.com/punk4464" leavesPage={true} />
                 </li>
-                <li>solimander</li>
+                <li>
+                  <Link
+                    text="@_solimander_"
+                    url="https://twitter.com/_solimander_"
+                    leavesPage={true}
+                  />
+                </li>
                 <li>
                   <Link text="@dhof" url="https://twitter.com/dhof" leavesPage={true} />
                 </li>


### PR DESCRIPTION
## TLDR

Names says it all. Soli didn't have a twitter when Nouns launched. Now he does. We should link to him.

## Testing done

Previewed on desktop and mobile. Confirmed it shows up right / links to twitter right. 