### PR TITLE
Make props on gov page actual links

### DIFF
--- a/packages/nouns-webapp/src/components/Proposals/Proposals.module.css
+++ b/packages/nouns-webapp/src/components/Proposals/Proposals.module.css
@@ -69,6 +69,9 @@
   font-size: 22px;
   font-family: 'PT Root UI';
   font-weight: bold;
+  text-decoration: none;
+  color: inherit;
+  margin-bottom: 1rem;
 }
 
 .proposalInfoWrapper {
@@ -81,6 +84,7 @@
 
 .proposalLink:hover {
   background: white;
+  color: inherit !important;
   cursor: pointer;
 }
 

--- a/packages/nouns-webapp/src/components/Proposals/index.tsx
+++ b/packages/nouns-webapp/src/components/Proposals/index.tsx
@@ -183,13 +183,6 @@ const Proposals = ({ proposals }: { proposals: Proposal[] }) => {
             return (
               <a
                 className={clsx(classes.proposalLink, classes.proposalLinkWithCountdown)}
-                // onClick={() => {
-                //   if (isMetaKeyPressed) {
-                //     window.open(`${window.location.origin}/vote/${p.id}`, '_blank');
-                //   } else {
-                //     history.push(`/vote/${p.id}`);
-                //   }
-                // }}
                 href={`/vote/${p.id}`}
                 key={i}
               >

--- a/packages/nouns-webapp/src/components/Proposals/index.tsx
+++ b/packages/nouns-webapp/src/components/Proposals/index.tsx
@@ -14,7 +14,7 @@ import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
 import { useActiveLocale } from '../../hooks/useActivateLocale';
 import { SUPPORTED_LOCALE_TO_DAYSJS_LOCALE, SupportedLocale } from '../../i18n/locales';
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import DelegationModal from '../DelegationModal';
 import { i18n } from '@lingui/core';
 import en from 'dayjs/locale/en';
@@ -77,30 +77,6 @@ const Proposals = ({ proposals }: { proposals: Proposal[] }) => {
   const isMobile = isMobileScreen();
   const activeLocale = useActiveLocale();
   const [showDelegateModal, setShowDelegateModal] = useState(false);
-  const [isMetaKeyPressed, setIsMetaKeyPressed] = useState(false);
-
-  // Key press handlers to meta key
-  // These allow us to support the mac meta+click to open in a new behavior
-  const metaKeyDownHandler = (event: { key: string }) => {
-    if (event.key === 'Meta') {
-      setIsMetaKeyPressed(true);
-    }
-  };
-
-  const metaKeyUpHandler = (event: { key: string }) => {
-    if (event.key === 'Meta') {
-      setIsMetaKeyPressed(false);
-    }
-  };
-
-  useEffect(() => {
-    window.addEventListener('keydown', metaKeyDownHandler);
-    window.addEventListener('keyup', metaKeyUpHandler);
-    return () => {
-      window.removeEventListener('keydown', metaKeyDownHandler);
-      window.removeEventListener('keyup', metaKeyUpHandler);
-    };
-  }, []);
 
   const threshold = (useProposalThreshold() ?? 0) + 1;
   const hasEnoughVotesToPropose = account !== undefined && connectedAccountNounVotes >= threshold;
@@ -205,15 +181,16 @@ const Proposals = ({ proposals }: { proposals: Proposal[] }) => {
             );
 
             return (
-              <div
+              <a
                 className={clsx(classes.proposalLink, classes.proposalLinkWithCountdown)}
-                onClick={() => {
-                  if (isMetaKeyPressed) {
-                    window.open(`${window.location.origin}/vote/${p.id}`, '_blank');
-                  } else {
-                    history.push(`/vote/${p.id}`);
-                  }
-                }}
+                // onClick={() => {
+                //   if (isMetaKeyPressed) {
+                //     window.open(`${window.location.origin}/vote/${p.id}`, '_blank');
+                //   } else {
+                //     history.push(`/vote/${p.id}`);
+                //   }
+                // }}
+                href={`/vote/${p.id}`}
                 key={i}
               >
                 <div className={classes.proposalInfoWrapper}>
@@ -233,7 +210,7 @@ const Proposals = ({ proposals }: { proposals: Proposal[] }) => {
                 {isPropInStateToHaveCountDown && (
                   <div className={classes.mobileCountdownWrapper}>{countdownPill}</div>
                 )}
-              </div>
+              </a>
             );
           })
       ) : (


### PR DESCRIPTION
## TLDR
Small fix to make the props on the `/vote` page actual `a` tags vs divs with `onClick` that opens the prop page. This allows people to right click, middle mouse click, meta key click and all that good stuff.

## Context

Ask from Oni:
https://discord.com/channels/849745721544146955/959548905807314944/1021564070425542718 

## Testing Done

-  confirm it worked as expected on desktop and mobile (right click, meta click, etc etc)