### PR TITLE
Increase `BLOCKS_PER_DAY`

### DIFF
--- a/packages/nouns-webapp/src/index.tsx
+++ b/packages/nouns-webapp/src/index.tsx
@@ -106,7 +106,7 @@ const Updaters = () => {
   );
 };
 
-const BLOCKS_PER_DAY = 6_500;
+const BLOCKS_PER_DAY = 7_200;
 
 const ChainSubscriber: React.FC = () => {
   const dispatch = useAppDispatch();
@@ -160,7 +160,7 @@ const ChainSubscriber: React.FC = () => {
     dispatch(setFullAuction(reduxSafeAuction(currentAuction)));
     dispatch(setLastAuctionNounId(currentAuction.nounId.toNumber()));
 
-    // Fetch the previous 24hours of  bids
+    // Fetch the previous 24 hours of bids
     const previousBids = await nounsAuctionHouseContract.queryFilter(bidFilter, 0 - BLOCKS_PER_DAY);
     for (let event of previousBids) {
       if (event.args === undefined) return;


### PR DESCRIPTION
Increase `BLOCKS_PER_DAY` to account for the change to a 12 second block time. Failure to look back far enough when loading bids was dropping early bids from the history.
