### PR TITLE
Remove Discord from web app

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The [nouns assets](packages/nouns-assets) package holds the Noun PNG and run-len
 
 ### nouns-bots
 
-The [nouns bots](packages/nouns-bots) package contains a bot that monitors for changes in Noun auction state and notifies everyone via Twitter.
+The [nouns bots](packages/nouns-bots) package contains a bot that monitors for changes in Noun auction state and notifies everyone via Twitter and Discord.
 
 ### nouns-contracts
 

--- a/README.md
+++ b/README.md
@@ -2,10 +2,6 @@
 
 Nouns DAO is a generative avatar art collective run by a group of crypto misfits.
 
-## Contributing
-
-If you're interested in contributing to Nouns DAO repos we're excited to have you. Please discuss any changes in `#developers` in [discord.gg/nouns](https://discord.gg/nouns) prior to contributing to reduce duplication of effort and in case there is any prior art that may be useful to you.
-
 ## Packages
 
 ### nouns-api
@@ -18,7 +14,7 @@ The [nouns assets](packages/nouns-assets) package holds the Noun PNG and run-len
 
 ### nouns-bots
 
-The [nouns bots](packages/nouns-bots) package contains a bot that monitors for changes in Noun auction state and notifies everyone via Twitter and Discord.
+The [nouns bots](packages/nouns-bots) package contains a bot that monitors for changes in Noun auction state and notifies everyone via Twitter.
 
 ### nouns-contracts
 

--- a/packages/nouns-webapp/functions/README.md
+++ b/packages/nouns-webapp/functions/README.md
@@ -2,10 +2,6 @@
 
 `nouns.wtf` provides a serverless API to make fetching data about the Nouns ecosystem easier. [An Insomnia manifest is provided for example.](./docs/insomnia.json)
 
-## Keeping Up To Date
-
-Nouns is a new project and these API endpoints may change, be sure to join [`#developers` in the Nouns Discord](https://discord.gg/nouns) to keep informed.
-
 ## API Convention
 
 `https://nouns.wtf/.netlify/functions/<version>/<function name>`

--- a/packages/nouns-webapp/public/_redirects
+++ b/packages/nouns-webapp/public/_redirects
@@ -1,3 +1,2 @@
-/discord	https://discord.gg/nouns	302
 /docs	https://nouns.notion.site/Explore-Nouns-a2a9dceeb1d54e10b9cbf3f931c2266f	302
 /*    /index.html   200

--- a/packages/nouns-webapp/src/components/Footer/index.tsx
+++ b/packages/nouns-webapp/src/components/Footer/index.tsx
@@ -8,7 +8,6 @@ import { Trans } from '@lingui/macro';
 
 const Footer = () => {
   const twitterURL = externalURL(ExternalURL.twitter);
-  const discordURL = externalURL(ExternalURL.discord);
   const etherscanURL = buildEtherscanAddressLink(config.addresses.nounsToken);
   const discourseURL = externalURL(ExternalURL.discourse);
 
@@ -16,7 +15,6 @@ const Footer = () => {
     <div className={classes.wrapper}>
       <Container className={classes.container}>
         <footer className={classes.footerSignature}>
-          <Link text={<Trans>Discord</Trans>} url={discordURL} leavesPage={true} />
           <Link text={<Trans>Twitter</Trans>} url={twitterURL} leavesPage={true} />
           <Link text={<Trans>Etherscan</Trans>} url={etherscanURL} leavesPage={true} />
           <Link text={<Trans>Forums</Trans>} url={discourseURL} leavesPage={false} />

--- a/packages/nouns-webapp/src/utils/externalURL.ts
+++ b/packages/nouns-webapp/src/utils/externalURL.ts
@@ -1,5 +1,4 @@
 export enum ExternalURL {
-  discord,
   twitter,
   notion,
   discourse,
@@ -8,8 +7,6 @@ export enum ExternalURL {
 
 export const externalURL = (externalURL: ExternalURL) => {
   switch (externalURL) {
-    case ExternalURL.discord:
-      return 'http://discord.gg/nouns';
     case ExternalURL.twitter:
       return 'https://twitter.com/nounsdao';
     case ExternalURL.notion:


### PR DESCRIPTION
As the official Discord is set to close down in the coming days, we should remove the attention being directed to it. 

This PR removes all instances of the official Nouns Discord link from the web app. 