### PR TITLE
Update Quorum Wording to Threshold

### DIFF
--- a/packages/nouns-webapp/src/components/DynamicQuorumInfoModal/index.tsx
+++ b/packages/nouns-webapp/src/components/DynamicQuorumInfoModal/index.tsx
@@ -79,20 +79,20 @@ const DynamicQuorumInfoModalOverlay: React.FC<{
       <div className={classes.modal}>
         <div className={classes.content}>
           <h1 className={classes.title}>
-            <Trans>Dynamic Quorum</Trans>
+            <Trans>Dynamic Threshold</Trans>
           </h1>
 
           <p className={classes.mainCopy}>
             {window.innerWidth < 1200 ? (
               <Trans>
-                The Quorum (minimum number of For votes required to pass a proposal) is set as a
+                The Threshold (minimum number of For votes required to pass a proposal) is set as a
                 function of the number of Against votes a proposal has recieved. It increases
                 quadratically as a function of the % of Nouns voting against a prop, varying between
-                Min Quorum and Max Quorum.
+                Min Threshold and Max Threshold.
               </Trans>
             ) : (
               <Trans>
-                The Quorum (minimum number of For votes required to pass a proposal) is set as a
+                The Threshold (minimum number of For votes required to pass a proposal) is set as a
                 function of the number of Against votes a proposal has recieved. The number of For
                 votes required to pass Proposal {proposal.id} is given by the following curve:
               </Trans>
@@ -102,11 +102,11 @@ const DynamicQuorumInfoModalOverlay: React.FC<{
           {/* Mobile - no graph content */}
           <div className={clsx(responsiveUiUtilsClasses.mobileOnly, classes.mobileQuorumWrapper)}>
             <div className={classes.mobileQuorumInfo}>
-              <span>Min Quorum:</span> {Math.floor((minQuorumBps * totalNounSupply) / 10_000)} Nouns
+              <span>Min Threshold:</span> {Math.floor((minQuorumBps * totalNounSupply) / 10_000)} Nouns
             </div>
 
             <div className={classes.mobileQuorumInfo}>
-              <span>Current Quorum:</span>{' '}
+              <span>Current Threshold:</span>{' '}
               {Math.floor(
                 (Math.min(maxQuorumBps, dqmFunction(againstVotesBps)) * totalNounSupply) / 10_000,
               )}{' '}
@@ -114,7 +114,7 @@ const DynamicQuorumInfoModalOverlay: React.FC<{
             </div>
 
             <div className={classes.mobileQuorumInfo}>
-              <span>Max Quorum:</span> {Math.floor((maxQuorumBps * totalNounSupply) / 10_000)} Nouns
+              <span>Max Threshold:</span> {Math.floor((maxQuorumBps * totalNounSupply) / 10_000)} Nouns
             </div>
           </div>
 
@@ -190,7 +190,7 @@ const DynamicQuorumInfoModalOverlay: React.FC<{
                   />
                   <circle cy={y} cx={x} r="7" fill="var(--brand-gray-light-text)" />
                   <text x="20" y="24">
-                    Max Quorum: {Math.floor((maxQuorumBps * totalNounSupply) / 10_000)} Nouns{' '}
+                    Max Threshold: {Math.floor((maxQuorumBps * totalNounSupply) / 10_000)} Nouns{' '}
                     <tspan fill="var(--brand-gray-light-text)">
                       ({maxQuorumBps / 100}% of Nouns)
                     </tspan>
@@ -198,7 +198,7 @@ const DynamicQuorumInfoModalOverlay: React.FC<{
                   {Math.abs(y - 10 - PLOTTING_CONSTANTS.minQHeightPlotSpace) > 100 ? (
                     <>
                       <text x="20" y="280">
-                        Min Quorum: {Math.floor((minQuorumBps * totalNounSupply) / 10_000)}{' '}
+                        Min Threshold: {Math.floor((minQuorumBps * totalNounSupply) / 10_000)}{' '}
                         {Math.floor((minQuorumBps * totalNounSupply) / 10_000) === 1
                           ? 'Noun'
                           : 'Nouns'}{' '}
@@ -210,7 +210,7 @@ const DynamicQuorumInfoModalOverlay: React.FC<{
                   ) : (
                     <>
                       <text x="550" y="280">
-                        Min Quorum: {Math.floor((minQuorumBps * totalNounSupply) / 10_000)} Nouns{' '}
+                        Min Threshold: {Math.floor((minQuorumBps * totalNounSupply) / 10_000)} Nouns{' '}
                         <tspan fill="var(--brand-gray-light-text)">
                           ({minQuorumBps / 100}% of Nouns)
                         </tspan>
@@ -228,7 +228,7 @@ const DynamicQuorumInfoModalOverlay: React.FC<{
                       x={x - 390}
                       y={y + (againstVotesBps > 0.9 * linearToConstantCrossoverBPS ? 20 : -10)}
                     >
-                      Current Quorum:{' '}
+                      Current Threshold:{' '}
                       {Math.floor(
                         (Math.min(maxQuorumBps, dqmFunction(againstVotesBps)) * totalNounSupply) /
                           10_000,
@@ -243,7 +243,7 @@ const DynamicQuorumInfoModalOverlay: React.FC<{
                       x={x + 10}
                       y={y + (againstVotesBps > 0.9 * linearToConstantCrossoverBPS ? 20 : -10)}
                     >
-                      Current Quorum:{' '}
+                      Current Threshold:{' '}
                       {Math.floor(
                         (Math.min(maxQuorumBps, dqmFunction(againstVotesBps)) * totalNounSupply) /
                           10_000,
@@ -276,7 +276,7 @@ const DynamicQuorumInfoModalOverlay: React.FC<{
 
           <p className={classes.moreDetailsCopy}>
             <Trans>
-              More details on how dynamic quorum works can be found{' '}
+              More details on how dynamic threshold works can be found{' '}
               <span className={classes.underline}>here</span>.
             </Trans>
           </p>
@@ -303,7 +303,7 @@ const DynamicQuorumInfoModal: React.FC<{
   );
 
   if (error) {
-    return <>Failed to fetch dynamic quorum info</>;
+    return <>Failed to fetch dynamic threshold info</>;
   }
 
   if (loading) {

--- a/packages/nouns-webapp/src/pages/Vote/index.tsx
+++ b/packages/nouns-webapp/src/pages/Vote/index.tsx
@@ -372,7 +372,7 @@ const VotePage = ({
                   </div>
                   {isV2Prop && (
                     <ReactTooltip
-                      id={'view-dq-info'}git 
+                      id={'view-dq-info'}
                       className={classes.delegateHover}
                       getContent={dataTip => {
                         return <Trans>View Dynamic Threshold Info</Trans>;

--- a/packages/nouns-webapp/src/pages/Vote/index.tsx
+++ b/packages/nouns-webapp/src/pages/Vote/index.tsx
@@ -372,10 +372,10 @@ const VotePage = ({
                   </div>
                   {isV2Prop && (
                     <ReactTooltip
-                      id={'view-dq-info'}
+                      id={'view-dq-info'}git
                       className={classes.delegateHover}
                       getContent={dataTip => {
-                        return <Trans>View Dynamic Quorum Info</Trans>;
+                        return <Trans>View Dynamic Threshold Info</Trans>;
                       }}
                     />
                   )}
@@ -385,7 +385,7 @@ const VotePage = ({
                     onClick={() => setShowDynamicQuorumInfoModal(true && isV2Prop)}
                     className={clsx(classes.thresholdInfo, isV2Prop ? classes.cursorPointer : '')}
                   >
-                    <span>{isV2Prop ? <Trans>Current Quorum</Trans> : <Trans>Quorum</Trans>}</span>
+                    <span>{isV2Prop ? <Trans>For Votes Required</Trans> : <Trans>Threshold</Trans>}</span>
                     <h3>
                       <Trans>
                         {isV2Prop ? i18n.number(currentQuorum ?? 0) : proposal.quorumVotes} votes

--- a/packages/nouns-webapp/src/pages/Vote/index.tsx
+++ b/packages/nouns-webapp/src/pages/Vote/index.tsx
@@ -372,7 +372,7 @@ const VotePage = ({
                   </div>
                   {isV2Prop && (
                     <ReactTooltip
-                      id={'view-dq-info'}git
+                      id={'view-dq-info'}git 
                       className={classes.delegateHover}
                       getContent={dataTip => {
                         return <Trans>View Dynamic Threshold Info</Trans>;


### PR DESCRIPTION
Since our dynamic quorum doesn't actually calculate based on a true quorum (a total number of participants), but actually calculates the yes votes required, I'm proposing to change the wording to make sure there is no confusion. Threshold is used in a couple areas, so I'm suggesting to update all the uses of quorum to the threshold wording. That way nobody who has been involved in any governing body before will think that votes will pass when they won't, as in Prop 159. 

Sorry for my sloppy commits. I'm very new at using github. 