### PR TITLE
Update DQ Copy

### DIFF
--- a/packages/nouns-webapp/src/components/DynamicQuorumInfoModal/index.tsx
+++ b/packages/nouns-webapp/src/components/DynamicQuorumInfoModal/index.tsx
@@ -30,6 +30,7 @@ const DynamicQuorumInfoModalOverlay: React.FC<{
   quorumCoefficent: number;
   totalNounSupply: number;
   onDismiss: () => void;
+  currentQuorum?: number;
 }> = props => {
   const {
     onDismiss,
@@ -40,6 +41,7 @@ const DynamicQuorumInfoModalOverlay: React.FC<{
     minQuorumBps,
     maxQuorumBps,
     totalNounSupply,
+    currentQuorum,
   } = props;
 
   const linearToConstantCrossoverBPS = (maxQuorumBps - minQuorumBps) / quorumCoefficent;
@@ -87,8 +89,8 @@ const DynamicQuorumInfoModalOverlay: React.FC<{
               <Trans>
                 The Threshold (minimum number of For votes required to pass a proposal) is set as a
                 function of the number of Against votes a proposal has recieved. It increases
-                linearlly as a function of the % of Nouns voting against a prop, varying between
-                Min Treshold and Max Treshold.
+                linearly as a function of the % of Nouns voting against a prop, varying between Min
+                Treshold and Max Treshold.
               </Trans>
             ) : (
               <Trans>
@@ -102,7 +104,8 @@ const DynamicQuorumInfoModalOverlay: React.FC<{
           {/* Mobile - no graph content */}
           <div className={clsx(responsiveUiUtilsClasses.mobileOnly, classes.mobileQuorumWrapper)}>
             <div className={classes.mobileQuorumInfo}>
-              <span>Min Treshold:</span> {Math.floor((minQuorumBps * totalNounSupply) / 10_000)} Nouns
+              <span>Min Treshold:</span> {Math.floor((minQuorumBps * totalNounSupply) / 10_000)}{' '}
+              Nouns
             </div>
 
             <div className={classes.mobileQuorumInfo}>
@@ -114,7 +117,8 @@ const DynamicQuorumInfoModalOverlay: React.FC<{
             </div>
 
             <div className={classes.mobileQuorumInfo}>
-              <span>Max Treshold:</span> {Math.floor((maxQuorumBps * totalNounSupply) / 10_000)} Nouns
+              <span>Max Treshold:</span> {Math.floor((maxQuorumBps * totalNounSupply) / 10_000)}{' '}
+              Nouns
             </div>
           </div>
 
@@ -228,11 +232,7 @@ const DynamicQuorumInfoModalOverlay: React.FC<{
                       x={x - 390}
                       y={y + (againstVotesBps > 0.9 * linearToConstantCrossoverBPS ? 20 : -10)}
                     >
-                      Current Threshold:{' '}
-                      {Math.floor(
-                        (Math.min(maxQuorumBps, dqmFunction(againstVotesBps)) * totalNounSupply) /
-                          10_000,
-                      )}{' '}
+                      Current Threshold: {currentQuorum}{' '}
                       <tspan fill="var(--brand-gray-light-text)">
                         ({againstVotesAbs} {againstVotesAbs === 1 ? 'Noun' : 'Nouns'} Currently
                         Against)
@@ -243,11 +243,7 @@ const DynamicQuorumInfoModalOverlay: React.FC<{
                       x={x + 10}
                       y={y + (againstVotesBps > 0.9 * linearToConstantCrossoverBPS ? 20 : -10)}
                     >
-                      Current Treshold:{' '}
-                      {Math.floor(
-                        (Math.min(maxQuorumBps, dqmFunction(againstVotesBps)) * totalNounSupply) /
-                          10_000,
-                      )}{' '}
+                      Current Treshold: {currentQuorum}{' '}
                       <tspan fill="var(--brand-gray-light-text)">
                         ({againstVotesAbs} {againstVotesAbs === 1 ? 'Noun' : 'Nouns'} Currently
                         Against)
@@ -290,8 +286,9 @@ const DynamicQuorumInfoModal: React.FC<{
   proposal: Proposal;
   againstVotesAbsolute: number;
   onDismiss: () => void;
+  currentQuorum?: number;
 }> = props => {
-  const { onDismiss, proposal, againstVotesAbsolute } = props;
+  const { onDismiss, proposal, againstVotesAbsolute, currentQuorum } = props;
 
   const { data, loading, error } = useQuery(
     totalNounSupplyAtPropSnapshot(proposal && proposal.id ? proposal.id : '0'),
@@ -334,6 +331,7 @@ const DynamicQuorumInfoModal: React.FC<{
           onDismiss={onDismiss}
           proposal={proposal}
           totalNounSupply={data.proposals[0].totalSupply}
+          currentQuorum={currentQuorum}
         />,
         document.getElementById('overlay-root')!,
       )}

--- a/packages/nouns-webapp/src/components/DynamicQuorumInfoModal/index.tsx
+++ b/packages/nouns-webapp/src/components/DynamicQuorumInfoModal/index.tsx
@@ -81,7 +81,7 @@ const DynamicQuorumInfoModalOverlay: React.FC<{
       <div className={classes.modal}>
         <div className={classes.content}>
           <h1 className={classes.title}>
-            <Trans>Dynamic Treshold</Trans>
+            <Trans>Dynamic Threshold</Trans>
           </h1>
 
           <p className={classes.mainCopy}>
@@ -90,7 +90,7 @@ const DynamicQuorumInfoModalOverlay: React.FC<{
                 The Threshold (minimum number of For votes required to pass a proposal) is set as a
                 function of the number of Against votes a proposal has recieved. It increases
                 linearly as a function of the % of Nouns voting against a prop, varying between Min
-                Treshold and Max Treshold.
+                Threshold and Max Threshold.
               </Trans>
             ) : (
               <Trans>
@@ -104,12 +104,12 @@ const DynamicQuorumInfoModalOverlay: React.FC<{
           {/* Mobile - no graph content */}
           <div className={clsx(responsiveUiUtilsClasses.mobileOnly, classes.mobileQuorumWrapper)}>
             <div className={classes.mobileQuorumInfo}>
-              <span>Min Treshold:</span> {Math.floor((minQuorumBps * totalNounSupply) / 10_000)}{' '}
+              <span>Min Threshold:</span> {Math.floor((minQuorumBps * totalNounSupply) / 10_000)}{' '}
               Nouns
             </div>
 
             <div className={classes.mobileQuorumInfo}>
-              <span>Current Treshold:</span>{' '}
+              <span>Current Threshold:</span>{' '}
               {Math.floor(
                 (Math.min(maxQuorumBps, dqmFunction(againstVotesBps)) * totalNounSupply) / 10_000,
               )}{' '}
@@ -117,7 +117,7 @@ const DynamicQuorumInfoModalOverlay: React.FC<{
             </div>
 
             <div className={classes.mobileQuorumInfo}>
-              <span>Max Treshold:</span> {Math.floor((maxQuorumBps * totalNounSupply) / 10_000)}{' '}
+              <span>Max Threshold:</span> {Math.floor((maxQuorumBps * totalNounSupply) / 10_000)}{' '}
               Nouns
             </div>
           </div>
@@ -194,7 +194,7 @@ const DynamicQuorumInfoModalOverlay: React.FC<{
                   />
                   <circle cy={y} cx={x} r="7" fill="var(--brand-gray-light-text)" />
                   <text x="20" y="24">
-                    Max Treshold: {Math.floor((maxQuorumBps * totalNounSupply) / 10_000)} Nouns{' '}
+                    Max Threshold: {Math.floor((maxQuorumBps * totalNounSupply) / 10_000)} Nouns{' '}
                     <tspan fill="var(--brand-gray-light-text)">
                       ({maxQuorumBps / 100}% of Nouns)
                     </tspan>
@@ -243,7 +243,7 @@ const DynamicQuorumInfoModalOverlay: React.FC<{
                       x={x + 10}
                       y={y + (againstVotesBps > 0.9 * linearToConstantCrossoverBPS ? 20 : -10)}
                     >
-                      Current Treshold: {currentQuorum}{' '}
+                      Current Threshold: {currentQuorum}{' '}
                       <tspan fill="var(--brand-gray-light-text)">
                         ({againstVotesAbs} {againstVotesAbs === 1 ? 'Noun' : 'Nouns'} Currently
                         Against)

--- a/packages/nouns-webapp/src/components/DynamicQuorumInfoModal/index.tsx
+++ b/packages/nouns-webapp/src/components/DynamicQuorumInfoModal/index.tsx
@@ -79,20 +79,20 @@ const DynamicQuorumInfoModalOverlay: React.FC<{
       <div className={classes.modal}>
         <div className={classes.content}>
           <h1 className={classes.title}>
-            <Trans>Dynamic Quorum</Trans>
+            <Trans>Dynamic Treshold</Trans>
           </h1>
 
           <p className={classes.mainCopy}>
             {window.innerWidth < 1200 ? (
               <Trans>
-                The Quorum (minimum number of For votes required to pass a proposal) is set as a
+                The Threshold (minimum number of For votes required to pass a proposal) is set as a
                 function of the number of Against votes a proposal has recieved. It increases
-                quadratically as a function of the % of Nouns voting against a prop, varying between
-                Min Quorum and Max Quorum.
+                linearlly as a function of the % of Nouns voting against a prop, varying between
+                Min Treshold and Max Treshold.
               </Trans>
             ) : (
               <Trans>
-                The Quorum (minimum number of For votes required to pass a proposal) is set as a
+                The Threshold (minimum number of For votes required to pass a proposal) is set as a
                 function of the number of Against votes a proposal has recieved. The number of For
                 votes required to pass Proposal {proposal.id} is given by the following curve:
               </Trans>
@@ -102,11 +102,11 @@ const DynamicQuorumInfoModalOverlay: React.FC<{
           {/* Mobile - no graph content */}
           <div className={clsx(responsiveUiUtilsClasses.mobileOnly, classes.mobileQuorumWrapper)}>
             <div className={classes.mobileQuorumInfo}>
-              <span>Min Quorum:</span> {Math.floor((minQuorumBps * totalNounSupply) / 10_000)} Nouns
+              <span>Min Treshold:</span> {Math.floor((minQuorumBps * totalNounSupply) / 10_000)} Nouns
             </div>
 
             <div className={classes.mobileQuorumInfo}>
-              <span>Current Quorum:</span>{' '}
+              <span>Current Treshold:</span>{' '}
               {Math.floor(
                 (Math.min(maxQuorumBps, dqmFunction(againstVotesBps)) * totalNounSupply) / 10_000,
               )}{' '}
@@ -114,7 +114,7 @@ const DynamicQuorumInfoModalOverlay: React.FC<{
             </div>
 
             <div className={classes.mobileQuorumInfo}>
-              <span>Max Quorum:</span> {Math.floor((maxQuorumBps * totalNounSupply) / 10_000)} Nouns
+              <span>Max Treshold:</span> {Math.floor((maxQuorumBps * totalNounSupply) / 10_000)} Nouns
             </div>
           </div>
 
@@ -190,7 +190,7 @@ const DynamicQuorumInfoModalOverlay: React.FC<{
                   />
                   <circle cy={y} cx={x} r="7" fill="var(--brand-gray-light-text)" />
                   <text x="20" y="24">
-                    Max Quorum: {Math.floor((maxQuorumBps * totalNounSupply) / 10_000)} Nouns{' '}
+                    Max Treshold: {Math.floor((maxQuorumBps * totalNounSupply) / 10_000)} Nouns{' '}
                     <tspan fill="var(--brand-gray-light-text)">
                       ({maxQuorumBps / 100}% of Nouns)
                     </tspan>
@@ -198,7 +198,7 @@ const DynamicQuorumInfoModalOverlay: React.FC<{
                   {Math.abs(y - 10 - PLOTTING_CONSTANTS.minQHeightPlotSpace) > 100 ? (
                     <>
                       <text x="20" y="280">
-                        Min Quorum: {Math.floor((minQuorumBps * totalNounSupply) / 10_000)}{' '}
+                        Min Threshold: {Math.floor((minQuorumBps * totalNounSupply) / 10_000)}{' '}
                         {Math.floor((minQuorumBps * totalNounSupply) / 10_000) === 1
                           ? 'Noun'
                           : 'Nouns'}{' '}
@@ -210,7 +210,7 @@ const DynamicQuorumInfoModalOverlay: React.FC<{
                   ) : (
                     <>
                       <text x="550" y="280">
-                        Min Quorum: {Math.floor((minQuorumBps * totalNounSupply) / 10_000)} Nouns{' '}
+                        Min Thresold: {Math.floor((minQuorumBps * totalNounSupply) / 10_000)} Nouns{' '}
                         <tspan fill="var(--brand-gray-light-text)">
                           ({minQuorumBps / 100}% of Nouns)
                         </tspan>
@@ -228,7 +228,7 @@ const DynamicQuorumInfoModalOverlay: React.FC<{
                       x={x - 390}
                       y={y + (againstVotesBps > 0.9 * linearToConstantCrossoverBPS ? 20 : -10)}
                     >
-                      Current Quorum:{' '}
+                      Current Threshold:{' '}
                       {Math.floor(
                         (Math.min(maxQuorumBps, dqmFunction(againstVotesBps)) * totalNounSupply) /
                           10_000,
@@ -243,7 +243,7 @@ const DynamicQuorumInfoModalOverlay: React.FC<{
                       x={x + 10}
                       y={y + (againstVotesBps > 0.9 * linearToConstantCrossoverBPS ? 20 : -10)}
                     >
-                      Current Quorum:{' '}
+                      Current Treshold:{' '}
                       {Math.floor(
                         (Math.min(maxQuorumBps, dqmFunction(againstVotesBps)) * totalNounSupply) /
                           10_000,
@@ -276,7 +276,7 @@ const DynamicQuorumInfoModalOverlay: React.FC<{
 
           <p className={classes.moreDetailsCopy}>
             <Trans>
-              More details on how dynamic quorum works can be found{' '}
+              More details on how the dynamic threshold works can be found{' '}
               <span className={classes.underline}>here</span>.
             </Trans>
           </p>
@@ -303,7 +303,7 @@ const DynamicQuorumInfoModal: React.FC<{
   );
 
   if (error) {
-    return <>Failed to fetch dynamic quorum info</>;
+    return <>Failed to fetch dynamic threshold info</>;
   }
 
   if (loading) {

--- a/packages/nouns-webapp/src/locales/en-US.po
+++ b/packages/nouns-webapp/src/locales/en-US.po
@@ -372,8 +372,12 @@ msgstr "Docs"
 #~ msgstr "Dynamic Quorum"
 
 #: src/components/DynamicQuorumInfoModal/index.tsx
-msgid "Dynamic Treshold"
-msgstr "Dynamic Treshold"
+msgid "Dynamic Threshold"
+msgstr "Dynamic Threshold"
+
+#: src/components/DynamicQuorumInfoModal/index.tsx
+#~ msgid "Dynamic Treshold"
+#~ msgstr "Dynamic Treshold"
 
 #: src/components/Banner/index.tsx
 msgid "EVERY DAY,"
@@ -937,8 +941,12 @@ msgstr "The Nouns community has undertaken a preliminary exploration of proposal
 #~ msgstr "The Quorum (minimum number of For votes required to pass a proposal) is set as a function of the number of Against votes a proposal has recieved. The number of For votes required to pass Proposal {0} is given by the following curve:"
 
 #: src/components/DynamicQuorumInfoModal/index.tsx
-msgid "The Threshold (minimum number of For votes required to pass a proposal) is set as a function of the number of Against votes a proposal has recieved. It increases linearly as a function of the % of Nouns voting against a prop, varying between Min Treshold and Max Treshold."
-msgstr "The Threshold (minimum number of For votes required to pass a proposal) is set as a function of the number of Against votes a proposal has recieved. It increases linearly as a function of the % of Nouns voting against a prop, varying between Min Treshold and Max Treshold."
+msgid "The Threshold (minimum number of For votes required to pass a proposal) is set as a function of the number of Against votes a proposal has recieved. It increases linearly as a function of the % of Nouns voting against a prop, varying between Min Threshold and Max Threshold."
+msgstr "The Threshold (minimum number of For votes required to pass a proposal) is set as a function of the number of Against votes a proposal has recieved. It increases linearly as a function of the % of Nouns voting against a prop, varying between Min Threshold and Max Threshold."
+
+#: src/components/DynamicQuorumInfoModal/index.tsx
+#~ msgid "The Threshold (minimum number of For votes required to pass a proposal) is set as a function of the number of Against votes a proposal has recieved. It increases linearly as a function of the % of Nouns voting against a prop, varying between Min Treshold and Max Treshold."
+#~ msgstr "The Threshold (minimum number of For votes required to pass a proposal) is set as a function of the number of Against votes a proposal has recieved. It increases linearly as a function of the % of Nouns voting against a prop, varying between Min Treshold and Max Treshold."
 
 #: src/components/DynamicQuorumInfoModal/index.tsx
 msgid "The Threshold (minimum number of For votes required to pass a proposal) is set as a function of the number of Against votes a proposal has recieved. The number of For votes required to pass Proposal {0} is given by the following curve:"

--- a/packages/nouns-webapp/src/locales/en-US.po
+++ b/packages/nouns-webapp/src/locales/en-US.po
@@ -292,8 +292,12 @@ msgid "Current Delegate"
 msgstr "Current"
 
 #: src/pages/Vote/index.tsx
-msgid "Current Quorum"
-msgstr "Current Quorum"
+#~ msgid "Current Quorum"
+#~ msgstr "Current Quorum"
+
+#: src/pages/Vote/index.tsx
+msgid "Current Threshold"
+msgstr "Current Threshold"
 
 #: src/components/CurrentBid/index.tsx
 msgid "Current bid"
@@ -352,8 +356,8 @@ msgid "Disconnect"
 msgstr "Disconnect"
 
 #: src/components/Footer/index.tsx
-msgid "Discord"
-msgstr "Discord"
+#~ msgid "Discord"
+#~ msgstr "Discord"
 
 #: src/components/NavBar/index.tsx
 msgid "Discourse"
@@ -364,8 +368,12 @@ msgid "Docs"
 msgstr "Docs"
 
 #: src/components/DynamicQuorumInfoModal/index.tsx
-msgid "Dynamic Quorum"
-msgstr "Dynamic Quorum"
+#~ msgid "Dynamic Quorum"
+#~ msgstr "Dynamic Quorum"
+
+#: src/components/DynamicQuorumInfoModal/index.tsx
+msgid "Dynamic Treshold"
+msgstr "Dynamic Treshold"
 
 #: src/components/Banner/index.tsx
 msgid "EVERY DAY,"
@@ -547,8 +555,12 @@ msgid "Making a proposal requires {threshold} votes"
 msgstr "Making a proposal requires {threshold} votes"
 
 #: src/components/DynamicQuorumInfoModal/index.tsx
-msgid "More details on how dynamic quorum works can be found <0>here</0>."
-msgstr "More details on how dynamic quorum works can be found <0>here</0>."
+#~ msgid "More details on how dynamic quorum works can be found <0>here</0>."
+#~ msgstr "More details on how dynamic quorum works can be found <0>here</0>."
+
+#: src/components/DynamicQuorumInfoModal/index.tsx
+msgid "More details on how the dynamic threshold works can be found <0>here</0>."
+msgstr "More details on how the dynamic threshold works can be found <0>here</0>."
 
 #: src/components/ProposalTransactionFormModal/index.tsx
 msgid "Next"
@@ -776,8 +788,8 @@ msgid "Queued"
 msgstr "Queued"
 
 #: src/pages/Vote/index.tsx
-msgid "Quorum"
-msgstr "Quorum"
+#~ msgid "Quorum"
+#~ msgstr "Quorum"
 
 #: src/components/VoteModal/index.tsx
 msgid "Reason (Optional)"
@@ -917,12 +929,20 @@ msgid "The Nouns community has undertaken a preliminary exploration of proposal 
 msgstr "The Nouns community has undertaken a preliminary exploration of proposal veto alternatives (‘rage quit’ etc.), but it is now clear that this is a difficult problem that will require significantly more research, development and testing before a satisfactory solution can be implemented."
 
 #: src/components/DynamicQuorumInfoModal/index.tsx
-msgid "The Quorum (minimum number of For votes required to pass a proposal) is set as a function of the number of Against votes a proposal has recieved. It increases quadratically as a function of the % of Nouns voting against a prop, varying between Min Quorum and Max Quorum."
-msgstr "The Quorum (minimum number of For votes required to pass a proposal) is set as a function of the number of Against votes a proposal has recieved. It increases quadratically as a function of the % of Nouns voting against a prop, varying between Min Quorum and Max Quorum."
+#~ msgid "The Quorum (minimum number of For votes required to pass a proposal) is set as a function of the number of Against votes a proposal has recieved. It increases quadratically as a function of the % of Nouns voting against a prop, varying between Min Quorum and Max Quorum."
+#~ msgstr "The Quorum (minimum number of For votes required to pass a proposal) is set as a function of the number of Against votes a proposal has recieved. It increases quadratically as a function of the % of Nouns voting against a prop, varying between Min Quorum and Max Quorum."
 
 #: src/components/DynamicQuorumInfoModal/index.tsx
-msgid "The Quorum (minimum number of For votes required to pass a proposal) is set as a function of the number of Against votes a proposal has recieved. The number of For votes required to pass Proposal {0} is given by the following curve:"
-msgstr "The Quorum (minimum number of For votes required to pass a proposal) is set as a function of the number of Against votes a proposal has recieved. The number of For votes required to pass Proposal {0} is given by the following curve:"
+#~ msgid "The Quorum (minimum number of For votes required to pass a proposal) is set as a function of the number of Against votes a proposal has recieved. The number of For votes required to pass Proposal {0} is given by the following curve:"
+#~ msgstr "The Quorum (minimum number of For votes required to pass a proposal) is set as a function of the number of Against votes a proposal has recieved. The number of For votes required to pass Proposal {0} is given by the following curve:"
+
+#: src/components/DynamicQuorumInfoModal/index.tsx
+msgid "The Threshold (minimum number of For votes required to pass a proposal) is set as a function of the number of Against votes a proposal has recieved. It increases linearly as a function of the % of Nouns voting against a prop, varying between Min Treshold and Max Treshold."
+msgstr "The Threshold (minimum number of For votes required to pass a proposal) is set as a function of the number of Against votes a proposal has recieved. It increases linearly as a function of the % of Nouns voting against a prop, varying between Min Treshold and Max Treshold."
+
+#: src/components/DynamicQuorumInfoModal/index.tsx
+msgid "The Threshold (minimum number of For votes required to pass a proposal) is set as a function of the number of Against votes a proposal has recieved. The number of For votes required to pass Proposal {0} is given by the following curve:"
+msgstr "The Threshold (minimum number of For votes required to pass a proposal) is set as a function of the number of Against votes a proposal has recieved. The number of For votes required to pass Proposal {0} is given by the following curve:"
 
 #: src/components/Documentation/index.tsx
 msgid "The compressed parts are efficiently converted into a single base64 encoded SVG image on-chain. To accomplish this, each part is decoded into an intermediate format before being converted into a series of SVG rects using batched, on-chain string concatenation. Once the entire SVG has been generated, it is base64 encoded."
@@ -956,6 +976,7 @@ msgstr "This Noun has no activity, since it was just created. Check back soon!"
 msgid "This treasury exists for <0>Nouns DAO</0> participants to allocate resources for the long-term growth and prosperity of the Nouns project."
 msgstr "This treasury exists for <0>Nouns DAO</0> participants to allocate resources for the long-term growth and prosperity of the Nouns project."
 
+#: src/pages/Vote/index.tsx
 #: src/pages/Vote/index.tsx
 msgid "Threshold"
 msgstr "Threshold"
@@ -1035,8 +1056,12 @@ msgid "Vetoed"
 msgstr "Vetoed"
 
 #: src/pages/Vote/index.tsx
-msgid "View Dynamic Quorum Info"
-msgstr "View Dynamic Quorum Info"
+#~ msgid "View Dynamic Quorum Info"
+#~ msgstr "View Dynamic Quorum Info"
+
+#: src/pages/Vote/index.tsx
+msgid "View Treshold Info"
+msgstr "View Treshold Info"
 
 #: src/components/BidHistoryBtn/index.tsx
 msgid "View all bids"

--- a/packages/nouns-webapp/src/locales/ja-JP.po
+++ b/packages/nouns-webapp/src/locales/ja-JP.po
@@ -377,8 +377,12 @@ msgstr "ドキュメント"
 #~ msgstr ""
 
 #: src/components/DynamicQuorumInfoModal/index.tsx
-msgid "Dynamic Treshold"
+msgid "Dynamic Threshold"
 msgstr ""
+
+#: src/components/DynamicQuorumInfoModal/index.tsx
+#~ msgid "Dynamic Treshold"
+#~ msgstr ""
 
 #: src/components/Banner/index.tsx
 msgid "EVERY DAY,"
@@ -942,8 +946,12 @@ msgstr ""
 #~ msgstr ""
 
 #: src/components/DynamicQuorumInfoModal/index.tsx
-msgid "The Threshold (minimum number of For votes required to pass a proposal) is set as a function of the number of Against votes a proposal has recieved. It increases linearly as a function of the % of Nouns voting against a prop, varying between Min Treshold and Max Treshold."
+msgid "The Threshold (minimum number of For votes required to pass a proposal) is set as a function of the number of Against votes a proposal has recieved. It increases linearly as a function of the % of Nouns voting against a prop, varying between Min Threshold and Max Threshold."
 msgstr ""
+
+#: src/components/DynamicQuorumInfoModal/index.tsx
+#~ msgid "The Threshold (minimum number of For votes required to pass a proposal) is set as a function of the number of Against votes a proposal has recieved. It increases linearly as a function of the % of Nouns voting against a prop, varying between Min Treshold and Max Treshold."
+#~ msgstr ""
 
 #: src/components/DynamicQuorumInfoModal/index.tsx
 msgid "The Threshold (minimum number of For votes required to pass a proposal) is set as a function of the number of Against votes a proposal has recieved. The number of For votes required to pass Proposal {0} is given by the following curve:"

--- a/packages/nouns-webapp/src/locales/ja-JP.po
+++ b/packages/nouns-webapp/src/locales/ja-JP.po
@@ -297,7 +297,11 @@ msgid "Current Delegate"
 msgstr "現在の代表者"
 
 #: src/pages/Vote/index.tsx
-msgid "Current Quorum"
+#~ msgid "Current Quorum"
+#~ msgstr ""
+
+#: src/pages/Vote/index.tsx
+msgid "Current Threshold"
 msgstr ""
 
 #: src/components/CurrentBid/index.tsx
@@ -357,8 +361,8 @@ msgid "Disconnect"
 msgstr "切断する"
 
 #: src/components/Footer/index.tsx
-msgid "Discord"
-msgstr "Discord"
+#~ msgid "Discord"
+#~ msgstr "Discord"
 
 #: src/components/NavBar/index.tsx
 msgid "Discourse"
@@ -369,7 +373,11 @@ msgid "Docs"
 msgstr "ドキュメント"
 
 #: src/components/DynamicQuorumInfoModal/index.tsx
-msgid "Dynamic Quorum"
+#~ msgid "Dynamic Quorum"
+#~ msgstr ""
+
+#: src/components/DynamicQuorumInfoModal/index.tsx
+msgid "Dynamic Treshold"
 msgstr ""
 
 #: src/components/Banner/index.tsx
@@ -552,7 +560,11 @@ msgid "Making a proposal requires {threshold} votes"
 msgstr ""
 
 #: src/components/DynamicQuorumInfoModal/index.tsx
-msgid "More details on how dynamic quorum works can be found <0>here</0>."
+#~ msgid "More details on how dynamic quorum works can be found <0>here</0>."
+#~ msgstr ""
+
+#: src/components/DynamicQuorumInfoModal/index.tsx
+msgid "More details on how the dynamic threshold works can be found <0>here</0>."
 msgstr ""
 
 #: src/components/ProposalTransactionFormModal/index.tsx
@@ -781,8 +793,8 @@ msgid "Queued"
 msgstr "キューに入りました"
 
 #: src/pages/Vote/index.tsx
-msgid "Quorum"
-msgstr "定足数"
+#~ msgid "Quorum"
+#~ msgstr "定足数"
 
 #: src/components/VoteModal/index.tsx
 msgid "Reason (Optional)"
@@ -922,11 +934,19 @@ msgid "The Nouns community has undertaken a preliminary exploration of proposal 
 msgstr ""
 
 #: src/components/DynamicQuorumInfoModal/index.tsx
-msgid "The Quorum (minimum number of For votes required to pass a proposal) is set as a function of the number of Against votes a proposal has recieved. It increases quadratically as a function of the % of Nouns voting against a prop, varying between Min Quorum and Max Quorum."
+#~ msgid "The Quorum (minimum number of For votes required to pass a proposal) is set as a function of the number of Against votes a proposal has recieved. It increases quadratically as a function of the % of Nouns voting against a prop, varying between Min Quorum and Max Quorum."
+#~ msgstr ""
+
+#: src/components/DynamicQuorumInfoModal/index.tsx
+#~ msgid "The Quorum (minimum number of For votes required to pass a proposal) is set as a function of the number of Against votes a proposal has recieved. The number of For votes required to pass Proposal {0} is given by the following curve:"
+#~ msgstr ""
+
+#: src/components/DynamicQuorumInfoModal/index.tsx
+msgid "The Threshold (minimum number of For votes required to pass a proposal) is set as a function of the number of Against votes a proposal has recieved. It increases linearly as a function of the % of Nouns voting against a prop, varying between Min Treshold and Max Treshold."
 msgstr ""
 
 #: src/components/DynamicQuorumInfoModal/index.tsx
-msgid "The Quorum (minimum number of For votes required to pass a proposal) is set as a function of the number of Against votes a proposal has recieved. The number of For votes required to pass Proposal {0} is given by the following curve:"
+msgid "The Threshold (minimum number of For votes required to pass a proposal) is set as a function of the number of Against votes a proposal has recieved. The number of For votes required to pass Proposal {0} is given by the following curve:"
 msgstr ""
 
 #: src/components/Documentation/index.tsx
@@ -961,6 +981,7 @@ msgstr "このNounは作成されたばかりで、動きがありません。�
 msgid "This treasury exists for <0>Nouns DAO</0> participants to allocate resources for the long-term growth and prosperity of the Nouns project."
 msgstr "このトレジャリーは、<0>Nouns DAO</0>の参加者がNounsプロジェクトの長期的な成長と繁栄目的に、リソースを配分するために存在しています。"
 
+#: src/pages/Vote/index.tsx
 #: src/pages/Vote/index.tsx
 msgid "Threshold"
 msgstr "しきい値"
@@ -1040,7 +1061,11 @@ msgid "Vetoed"
 msgstr "拒否"
 
 #: src/pages/Vote/index.tsx
-msgid "View Dynamic Quorum Info"
+#~ msgid "View Dynamic Quorum Info"
+#~ msgstr ""
+
+#: src/pages/Vote/index.tsx
+msgid "View Treshold Info"
 msgstr ""
 
 #: src/components/BidHistoryBtn/index.tsx

--- a/packages/nouns-webapp/src/locales/pseudo.po
+++ b/packages/nouns-webapp/src/locales/pseudo.po
@@ -292,7 +292,11 @@ msgid "Current Delegate"
 msgstr ""
 
 #: src/pages/Vote/index.tsx
-msgid "Current Quorum"
+#~ msgid "Current Quorum"
+#~ msgstr ""
+
+#: src/pages/Vote/index.tsx
+msgid "Current Threshold"
 msgstr ""
 
 #: src/components/CurrentBid/index.tsx
@@ -352,8 +356,8 @@ msgid "Disconnect"
 msgstr ""
 
 #: src/components/Footer/index.tsx
-msgid "Discord"
-msgstr ""
+#~ msgid "Discord"
+#~ msgstr ""
 
 #: src/components/NavBar/index.tsx
 msgid "Discourse"
@@ -364,7 +368,11 @@ msgid "Docs"
 msgstr ""
 
 #: src/components/DynamicQuorumInfoModal/index.tsx
-msgid "Dynamic Quorum"
+#~ msgid "Dynamic Quorum"
+#~ msgstr ""
+
+#: src/components/DynamicQuorumInfoModal/index.tsx
+msgid "Dynamic Treshold"
 msgstr ""
 
 #: src/components/Banner/index.tsx
@@ -547,7 +555,11 @@ msgid "Making a proposal requires {threshold} votes"
 msgstr ""
 
 #: src/components/DynamicQuorumInfoModal/index.tsx
-msgid "More details on how dynamic quorum works can be found <0>here</0>."
+#~ msgid "More details on how dynamic quorum works can be found <0>here</0>."
+#~ msgstr ""
+
+#: src/components/DynamicQuorumInfoModal/index.tsx
+msgid "More details on how the dynamic threshold works can be found <0>here</0>."
 msgstr ""
 
 #: src/components/ProposalTransactionFormModal/index.tsx
@@ -776,8 +788,8 @@ msgid "Queued"
 msgstr ""
 
 #: src/pages/Vote/index.tsx
-msgid "Quorum"
-msgstr ""
+#~ msgid "Quorum"
+#~ msgstr ""
 
 #: src/components/VoteModal/index.tsx
 msgid "Reason (Optional)"
@@ -917,11 +929,19 @@ msgid "The Nouns community has undertaken a preliminary exploration of proposal 
 msgstr ""
 
 #: src/components/DynamicQuorumInfoModal/index.tsx
-msgid "The Quorum (minimum number of For votes required to pass a proposal) is set as a function of the number of Against votes a proposal has recieved. It increases quadratically as a function of the % of Nouns voting against a prop, varying between Min Quorum and Max Quorum."
+#~ msgid "The Quorum (minimum number of For votes required to pass a proposal) is set as a function of the number of Against votes a proposal has recieved. It increases quadratically as a function of the % of Nouns voting against a prop, varying between Min Quorum and Max Quorum."
+#~ msgstr ""
+
+#: src/components/DynamicQuorumInfoModal/index.tsx
+#~ msgid "The Quorum (minimum number of For votes required to pass a proposal) is set as a function of the number of Against votes a proposal has recieved. The number of For votes required to pass Proposal {0} is given by the following curve:"
+#~ msgstr ""
+
+#: src/components/DynamicQuorumInfoModal/index.tsx
+msgid "The Threshold (minimum number of For votes required to pass a proposal) is set as a function of the number of Against votes a proposal has recieved. It increases linearly as a function of the % of Nouns voting against a prop, varying between Min Treshold and Max Treshold."
 msgstr ""
 
 #: src/components/DynamicQuorumInfoModal/index.tsx
-msgid "The Quorum (minimum number of For votes required to pass a proposal) is set as a function of the number of Against votes a proposal has recieved. The number of For votes required to pass Proposal {0} is given by the following curve:"
+msgid "The Threshold (minimum number of For votes required to pass a proposal) is set as a function of the number of Against votes a proposal has recieved. The number of For votes required to pass Proposal {0} is given by the following curve:"
 msgstr ""
 
 #: src/components/Documentation/index.tsx
@@ -956,6 +976,7 @@ msgstr ""
 msgid "This treasury exists for <0>Nouns DAO</0> participants to allocate resources for the long-term growth and prosperity of the Nouns project."
 msgstr ""
 
+#: src/pages/Vote/index.tsx
 #: src/pages/Vote/index.tsx
 msgid "Threshold"
 msgstr ""
@@ -1035,7 +1056,11 @@ msgid "Vetoed"
 msgstr ""
 
 #: src/pages/Vote/index.tsx
-msgid "View Dynamic Quorum Info"
+#~ msgid "View Dynamic Quorum Info"
+#~ msgstr ""
+
+#: src/pages/Vote/index.tsx
+msgid "View Treshold Info"
 msgstr ""
 
 #: src/components/BidHistoryBtn/index.tsx

--- a/packages/nouns-webapp/src/locales/pseudo.po
+++ b/packages/nouns-webapp/src/locales/pseudo.po
@@ -372,8 +372,12 @@ msgstr ""
 #~ msgstr ""
 
 #: src/components/DynamicQuorumInfoModal/index.tsx
-msgid "Dynamic Treshold"
+msgid "Dynamic Threshold"
 msgstr ""
+
+#: src/components/DynamicQuorumInfoModal/index.tsx
+#~ msgid "Dynamic Treshold"
+#~ msgstr ""
 
 #: src/components/Banner/index.tsx
 msgid "EVERY DAY,"
@@ -937,8 +941,12 @@ msgstr ""
 #~ msgstr ""
 
 #: src/components/DynamicQuorumInfoModal/index.tsx
-msgid "The Threshold (minimum number of For votes required to pass a proposal) is set as a function of the number of Against votes a proposal has recieved. It increases linearly as a function of the % of Nouns voting against a prop, varying between Min Treshold and Max Treshold."
+msgid "The Threshold (minimum number of For votes required to pass a proposal) is set as a function of the number of Against votes a proposal has recieved. It increases linearly as a function of the % of Nouns voting against a prop, varying between Min Threshold and Max Threshold."
 msgstr ""
+
+#: src/components/DynamicQuorumInfoModal/index.tsx
+#~ msgid "The Threshold (minimum number of For votes required to pass a proposal) is set as a function of the number of Against votes a proposal has recieved. It increases linearly as a function of the % of Nouns voting against a prop, varying between Min Treshold and Max Treshold."
+#~ msgstr ""
 
 #: src/components/DynamicQuorumInfoModal/index.tsx
 msgid "The Threshold (minimum number of For votes required to pass a proposal) is set as a function of the number of Against votes a proposal has recieved. The number of For votes required to pass Proposal {0} is given by the following curve:"

--- a/packages/nouns-webapp/src/pages/Vote/index.tsx
+++ b/packages/nouns-webapp/src/pages/Vote/index.tsx
@@ -375,7 +375,7 @@ const VotePage = ({
                       id={'view-dq-info'}
                       className={classes.delegateHover}
                       getContent={dataTip => {
-                        return <Trans>View Dynamic Quorum Info</Trans>;
+                        return <Trans>View Treshold Info</Trans>;
                       }}
                     />
                   )}
@@ -385,7 +385,7 @@ const VotePage = ({
                     onClick={() => setShowDynamicQuorumInfoModal(true && isV2Prop)}
                     className={clsx(classes.thresholdInfo, isV2Prop ? classes.cursorPointer : '')}
                   >
-                    <span>{isV2Prop ? <Trans>Current Quorum</Trans> : <Trans>Quorum</Trans>}</span>
+                    <span>{isV2Prop ? <Trans>Current Threshold</Trans> : <Trans>Threshold</Trans>}</span>
                     <h3>
                       <Trans>
                         {isV2Prop ? i18n.number(currentQuorum ?? 0) : proposal.quorumVotes} votes

--- a/packages/nouns-webapp/src/pages/Vote/index.tsx
+++ b/packages/nouns-webapp/src/pages/Vote/index.tsx
@@ -284,6 +284,7 @@ const VotePage = ({
           proposal={proposal}
           againstVotesAbsolute={againstNouns.length}
           onDismiss={() => setShowDynamicQuorumInfoModal(false)}
+          currentQuorum={currentQuorum}
         />
       )}
       <VoteModal
@@ -385,7 +386,9 @@ const VotePage = ({
                     onClick={() => setShowDynamicQuorumInfoModal(true && isV2Prop)}
                     className={clsx(classes.thresholdInfo, isV2Prop ? classes.cursorPointer : '')}
                   >
-                    <span>{isV2Prop ? <Trans>Current Threshold</Trans> : <Trans>Threshold</Trans>}</span>
+                    <span>
+                      {isV2Prop ? <Trans>Current Threshold</Trans> : <Trans>Threshold</Trans>}
+                    </span>
                     <h3>
                       <Trans>
                         {isV2Prop ? i18n.number(currentQuorum ?? 0) : proposal.quorumVotes} votes


### PR DESCRIPTION
Per #624 updating copy from "Dynamic Quorum" to "Dynamic Threshold" + fixing a small bug (ensuring that modal uses treshold value from the chain to make sure they match ... in at least one case before they were off by 1 due to rounding issues). 

Thanks to @andrewladdusaw and others for flagging this copy issue