### PR TITLE
fix typo & icon change on mobile nav

### DIFF
--- a/packages/nouns-webapp/src/components/NavBar/NavBar.module.css
+++ b/packages/nouns-webapp/src/components/NavBar/NavBar.module.css
@@ -128,3 +128,11 @@
   width: 100%;
   border: none;
 }
+/* Unique styling for non-fa icon on Explore button */
+@media (max-width: 992px) {
+  .exploreButton svg {
+    max-height: none;
+    min-height: 40px;
+    max-width: 40px;
+  }
+}

--- a/packages/nouns-webapp/src/components/NavBar/index.tsx
+++ b/packages/nouns-webapp/src/components/NavBar/index.tsx
@@ -136,10 +136,10 @@ const NavBar = () => {
                   buttonStyle={nonWalletButtonStyle}
                 />
               </Nav.Link>
-              <Nav.Link as={Link} to="/explore" className={classes.nounsNavLink} onClick={closeNav}>
+              <Nav.Link as={Link} to="/explore" className={clsx(classes.nounsNavLink, classes.exploreButton)} onClick={closeNav}>
                 <NavBarButton
                   buttonText={<Trans>Nouns &amp; Traits</Trans>}
-                  buttonIcon={<FontAwesomeIcon icon={faStar} />}
+                  buttonIcon={<Noggles />}
                   buttonStyle={nonWalletButtonStyle}
                 />
               </Nav.Link>

--- a/packages/nouns-webapp/src/components/NavBar/index.tsx
+++ b/packages/nouns-webapp/src/components/NavBar/index.tsx
@@ -129,7 +129,7 @@ const NavBar = () => {
               />
             </Nav.Link>
             <div className={clsx(responsiveUiUtilsClasses.mobileOnly)}>
-              <Nav.Link as={Link} to="/explore" className={classes.nounsNavLink} onClick={closeNav}>
+              <Nav.Link as={Link} to="/playground" className={classes.nounsNavLink} onClick={closeNav}>
                 <NavBarButton
                   buttonText={<Trans>Playground</Trans>}
                   buttonIcon={<FontAwesomeIcon icon={faPlay} />}


### PR DESCRIPTION
- the playground link in the mobile nav was linking to `/explore` instead of `/playground`. this has been resolved. 
- the mobile  `Explore` button now uses the ⌐◨-◨ icon instead of the font awesome star. 