### PR TITLE
Increase Record Count for Noun Activity Subgraph Requests

### DIFF
--- a/packages/nouns-webapp/src/wrappers/subgraph.ts
+++ b/packages/nouns-webapp/src/wrappers/subgraph.ts
@@ -219,11 +219,11 @@ export const latestBidsQuery = (first: number = 10) => gql`
   }  
 `;
 
-export const nounVotingHistoryQuery = (nounId: number) => gql`
+export const nounVotingHistoryQuery = (nounId: number, first = 1_000) => gql`
 {
 	noun(id: ${nounId}) {
 		id
-		votes {
+		votes(first: ${first}) {
       blockNumber
       proposal {
         id
@@ -238,9 +238,9 @@ export const nounVotingHistoryQuery = (nounId: number) => gql`
 }
 `;
 
-export const nounTransferHistoryQuery = (nounId: number) => gql`
+export const nounTransferHistoryQuery = (nounId: number, first = 1_000) => gql`
 {
-  transferEvents(where: {noun: "${nounId}"}) {
+  transferEvents(where: {noun: "${nounId}"}, first: ${first}) {
     id
     previousHolder {
       id
@@ -253,9 +253,9 @@ export const nounTransferHistoryQuery = (nounId: number) => gql`
 }
 `;
 
-export const nounDelegationHistoryQuery = (nounId: number) => gql`
+export const nounDelegationHistoryQuery = (nounId: number, first = 1_000) => gql`
 {
-  delegationEvents(where: {noun: "${nounId}"}) {
+  delegationEvents(where: {noun: "${nounId}"}, first: ${first}) {
     id
     previousDelegate {
       id


### PR DESCRIPTION
Noun history is getting cutoff because TheGraph only returns 100 records by default. Kick the can down the road by requesting the maximum allowable number of records (1000).