### PR TITLE
fix useAllProposalsViaChain (subgraph fallback)

### DIFF
--- a/packages/nouns-webapp/src/wrappers/nounsDao.ts
+++ b/packages/nouns-webapp/src/wrappers/nounsDao.ts
@@ -429,7 +429,7 @@ export const useAllProposalsViaChain = (skip = false): ProposalData => {
     }));
   };
 
-  const proposals = useContractCalls<ProposalCallResult>(requests('proposals'));
+  const proposals = useContractCalls<[ProposalCallResult]>(requests('proposals'));
   const proposalStates = useContractCalls<[ProposalState]>(requests('state'));
 
   const formattedLogs = useFormattedProposalCreatedLogs(skip);
@@ -442,7 +442,8 @@ export const useAllProposalsViaChain = (skip = false): ProposalData => {
     }
 
     return {
-      data: proposals.map((proposal, i) => {
+      data: proposals.map((p, i) => {
+        const proposal = p?.[0];
         const description = logs[i]?.description?.replace(/\\n/g, '\n');
         return {
           id: proposal?.id.toString(),


### PR DESCRIPTION
this was broken since DAOV2 contract
the abi for the `proposals` function is defined as returning a struct so it requires unpacking it before using