### PR TITLE
Fixed broken winners link

### DIFF
--- a/packages/nouns-webapp/src/components/Winner/index.tsx
+++ b/packages/nouns-webapp/src/components/Winner/index.tsx
@@ -42,13 +42,23 @@ const Winner: React.FC<WinnerProps> = props => {
       {!isMobile && (
         <Col>
           <a
-            href="https://nouns.center/nouners"
+            href="https://nouns.center/groups"
             target="_blank"
             rel="noreferrer noopener"
             className={classes.verifyLink}
           >
             <Button className={classes.verifyButton}>
-              <Trans>What now?</Trans>
+              <Trans>Get Involved</Trans>
+            </Button>
+          </a>
+          <a
+            href="https://www.nounsagora.com/"
+            target="_blank"
+            rel="noreferrer noopener"
+            className={classes.verifyLink}
+          >
+            <Button className={classes.verifyButton}>
+              <Trans>Delegate</Trans>
             </Button>
           </a>
         </Col>
@@ -104,13 +114,23 @@ const Winner: React.FC<WinnerProps> = props => {
       {isWinnerYou && isMobile && (
         <Row>
           <a
-            href="https://nouns.center/nouners"
+            href="https://nouns.center/groups"
             target="_blank"
             rel="noreferrer noopener"
             className={classes.verifyLink}
           >
             <Button className={classes.verifyButton}>
-              <Trans>What now?</Trans>
+              <Trans>Get Involved</Trans>
+            </Button>
+          </a>
+          <a
+            href="https://www.nounsagora.com/"
+            target="_blank"
+            rel="noreferrer noopener"
+            className={classes.verifyLink}
+          >
+            <Button className={classes.verifyButton}>
+              <Trans>Delegate</Trans>
             </Button>
           </a>
         </Row>


### PR DESCRIPTION
Currently, the site suggests auction winners visit a dead link on nouns center. This PR makes a minor edit to: 
1. Replace the dead nouns center link with a fresh one pointing to various active discord groups.
2. Adds a new link pointing to nounsagora.com

The thinking is that this caters to the two types of winners: those looking to actively engage should join the discussion, while those who are simply looking to hold the asset can find a delegate for their vote