### PR TITLE
Display Raw Calldata in Proposal Actions

### DIFF
--- a/packages/nouns-webapp/src/components/ProposalContent/index.tsx
+++ b/packages/nouns-webapp/src/components/ProposalContent/index.tsx
@@ -65,21 +65,27 @@ const ProposalContent: React.FC<ProposalContentProps> = props => {
               return (
                 <li key={i} className="m-0">
                   {linkIfAddress(d.target)}.{d.functionSig}
-                  {d.value}(
-                  <br />
-                  {d.callData.split(',').map((content, i) => {
-                    return (
-                      <Fragment key={i}>
-                        <span key={i}>
-                          &emsp;
-                          {linkIfAddress(content)}
-                          {d.callData.split(',').length - 1 === i ? '' : ','}
-                        </span>
-                        <br />
-                      </Fragment>
-                    );
-                  })}
-                  )
+                  {d.value}
+                  {!!d.functionSig ? (
+                    <>
+                      (<br />
+                      {d.callData.split(',').map((content, i) => {
+                        return (
+                          <Fragment key={i}>
+                            <span key={i}>
+                              &emsp;
+                              {linkIfAddress(content)}
+                              {d.callData.split(',').length - 1 === i ? '' : ','}
+                            </span>
+                            <br />
+                          </Fragment>
+                        );
+                      })}
+                      )
+                    </>
+                  ) : (
+                    d.callData
+                  )}
                   {d.target.toLowerCase() === config.addresses.tokenBuyer?.toLowerCase() && (
                     <div className={classes.txnInfoText}>
                       <div className={classes.txnInfoIconWrapper}>

--- a/packages/nouns-webapp/src/wrappers/nounsDao.ts
+++ b/packages/nouns-webapp/src/wrappers/nounsDao.ts
@@ -289,18 +289,29 @@ const formatProposalTransactionDetails = (details: ProposalTransactionDetails | 
       // Handle both logs and subgraph responses
       (details as ProposalTransactionDetails).values?.[i] ?? (details as Result)?.[3]?.[i] ?? 0,
     );
+    const callData = details.calldatas[i];
+
     // Split at first occurrence of '('
     let [name, types] = signature.substring(0, signature.length - 1)?.split(/\((.*)/s);
     if (!name || !types) {
+      // If there's no signature and calldata is present, display the raw calldata
+      if (callData && callData !== '0x') {
+        return {
+          target,
+          callData,
+          value: value.gt(0) ? `{ value: ${utils.formatEther(value)} ETH } ` : '',
+        };
+      }
+
       return {
         target,
         functionSig: name === '' ? 'transfer' : name === undefined ? 'unknown' : name,
         callData: types ? types : value ? `${utils.formatEther(value)} ETH` : '',
       };
     }
-    const calldata = details.calldatas[i];
+
     // Split using comma as separator, unless comma is between parentheses (tuple).
-    const decoded = defaultAbiCoder.decode(types.split(/,(?![^(]*\))/g), calldata);
+    const decoded = defaultAbiCoder.decode(types.split(/,(?![^(]*\))/g), callData);
     return {
       target,
       functionSig: name,


### PR DESCRIPTION
Display raw calldata in proposal calls that have data, but no signature.