### PR TITLE
fixed cryptopunks spelling to 'CryptoPunks'. Updated link.

### DIFF
--- a/packages/nouns-webapp/src/components/Documentation/index.tsx
+++ b/packages/nouns-webapp/src/components/Documentation/index.tsx
@@ -12,8 +12,8 @@ interface DocumentationProps {
 const Documentation = (props: DocumentationProps = { backgroundColor: '#FFF' }) => {
   const cryptopunksLink = (
     <Link
-      text={<Trans>Cryptopunks</Trans>}
-      url="https://www.larvalabs.com/cryptopunks"
+      text={<Trans>CryptoPunks</Trans>}
+      url="https://cryptopunks.app/"
       leavesPage={true}
     />
   );


### PR DESCRIPTION
"Cryptopunks web app will soon be moving to [cryptopunks.app](https://cryptopunks.app/)."