### PR TITLE
audit fix: fork auction griefing

### DIFF
--- a/packages/nouns-contracts/contracts/governance/fork/newdao/token/NounsTokenFork.sol
+++ b/packages/nouns-contracts/contracts/governance/fork/newdao/token/NounsTokenFork.sol
@@ -164,13 +164,24 @@ contract NounsTokenFork is INounsTokenFork, OwnableUpgradeable, ERC721Checkpoint
      * @param tokenIds The token IDs to claim
      */
     function claimDuringForkPeriod(address to, uint256[] calldata tokenIds) external {
+        uint256 currentNounId = _currentNounId;
+        uint256 maxNounId = 0;
         if (msg.sender != escrow.dao()) revert OnlyOriginalDAO();
         if (block.timestamp > forkingPeriodEndTimestamp) revert OnlyDuringForkingPeriod();
 
         for (uint256 i = 0; i < tokenIds.length; i++) {
             uint256 nounId = tokenIds[i];
             _mintWithOriginalSeed(to, nounId);
+
+            if (tokenIds[i] > maxNounId) maxNounId = tokenIds[i];
         }
+
+        // This treats an important case:
+        // During a forking period, people can buy new Nouns on auction, with a higher ID than the auction ID at forking
+        // They can then join the fork with those IDs
+        // If we don't increment currentNounId, unpausing the fork auction house would revert
+        // Since it would attempt to mint a noun with an ID that already exists
+        if (maxNounId >= currentNounId) _currentNounId = maxNounId + 1;
     }
 
     /**

--- a/packages/nouns-contracts/test/foundry/governance/fork/ForkingEndToEnd.t.sol
+++ b/packages/nouns-contracts/test/foundry/governance/fork/ForkingEndToEnd.t.sol
@@ -172,19 +172,23 @@ abstract contract ForkDAOBase is DeployUtilsFork {
     address originalNouner = makeAddr('original nouner');
     address newNouner = makeAddr('new nouner');
     address proposalRecipient = makeAddr('recipient');
+    address joiningNouner = makeAddr('joining nouner');
 
-    function setUp() public {
+    function setUp() public virtual {
         originalDAO = _deployDAOV3();
         originalToken = originalDAO.nouns();
         address originalMinter = originalToken.minter();
+        vm.startPrank(address(originalDAO.timelock()));
+        NounsAuctionHouseFork(originalMinter).unpause();
+        vm.stopPrank();
 
-        vm.startPrank(originalMinter);
-        originalToken.mint();
-        originalToken.mint();
-        originalToken.transferFrom(originalMinter, originalNouner, 1);
-        originalToken.transferFrom(originalMinter, originalNouner, 2);
+        vm.deal(originalNouner, 1 ether);
+        vm.deal(joiningNouner, 1 ether);
 
-        changePrank(originalNouner);
+        bidAndSettleOriginalAuction(originalNouner);
+        bidAndSettleOriginalAuction(originalNouner);
+
+        vm.startPrank(originalNouner);
         uint256[] memory tokenIds = new uint256[](2);
         tokenIds[0] = 1;
         tokenIds[1] = 2;
@@ -203,17 +207,27 @@ abstract contract ForkDAOBase is DeployUtilsFork {
         vm.roll(block.number + 1);
     }
 
-    function bidAndSettleAuction() internal {
-        INounsAuctionHouse.Auction memory auction = getAuction();
-        uint256 newNounId = auction.nounId;
-        forkAuction.createBid{ value: 0.1 ether }(newNounId);
-        vm.warp(block.timestamp + auction.endTime);
-        forkAuction.settleCurrentAndCreateNewAuction();
-        assertEq(forkToken.ownerOf(newNounId), newNouner);
-        vm.roll(block.number + 1);
+    function bidAndSettleForkAuction(address buyer) internal {
+        bidAndSettleAuction(forkAuction, buyer);
     }
 
-    function getAuction() internal view returns (INounsAuctionHouse.Auction memory) {
+    function bidAndSettleOriginalAuction(address buyer) internal {
+        bidAndSettleAuction(NounsAuctionHouseFork(originalToken.minter()), buyer);
+    }
+
+    function bidAndSettleAuction(NounsAuctionHouseFork auctionHouse, address buyer) internal {
+        vm.startPrank(buyer);
+        INounsAuctionHouse.Auction memory auction = getAuction(auctionHouse);
+        uint256 newNounId = auction.nounId;
+        auctionHouse.createBid{ value: 0.1 ether }(newNounId);
+        vm.warp(block.timestamp + auction.endTime);
+        auctionHouse.settleCurrentAndCreateNewAuction();
+        assertEq(auctionHouse.nouns().ownerOf(newNounId), buyer);
+        vm.roll(block.number + 1);
+        vm.stopPrank();
+    }
+
+    function getAuction(NounsAuctionHouseFork auctionHouse) internal view returns (INounsAuctionHouse.Auction memory) {
         (
             uint256 nounId,
             uint256 amount,
@@ -221,7 +235,7 @@ abstract contract ForkDAOBase is DeployUtilsFork {
             uint256 endTime,
             address payable bidder,
             bool settled
-        ) = forkAuction.auction();
+        ) = auctionHouse.auction();
 
         return INounsAuctionHouse.Auction(nounId, amount, startTime, endTime, bidder, settled);
     }
@@ -262,10 +276,11 @@ contract ForkDAOProposalAndAuctionHappyFlowTest is ForkDAOBase {
 
         // Buy a fork noun on auction as newNouner
         vm.deal(newNouner, 1 ether);
-        changePrank(newNouner);
-        bidAndSettleAuction();
+        vm.stopPrank();
+        bidAndSettleForkAuction(newNouner);
 
         // Execute a proposal created by newNouner
+        vm.startPrank(newNouner);
         vm.deal(address(forkTreasury), 0.142 ether);
         uint256 transferProp = proposeToForkAndRollToVoting(proposalRecipient, 0.142 ether, '', '');
         forkDAO.castVote(transferProp, 1);
@@ -293,6 +308,32 @@ contract ForkDAOCanUpgradeItsTokenTest is ForkDAOBase {
         queueAndExecute(propId);
 
         assertTrue(TokenUpgrade(address(forkToken)).theUpgradeWorked());
+    }
+}
+
+contract ForkDAO_PostFork_NewOGNounsJoin is ForkDAOBase {
+    function test_forkAuctionHouseUnpauseWorks() public {
+        // buy new nouns on auction
+        bidAndSettleOriginalAuction(joiningNouner);
+        bidAndSettleOriginalAuction(joiningNouner);
+
+        // join the fork with new noun IDs
+        changePrank(joiningNouner);
+        uint256[] memory tokenIds = new uint256[](2);
+        tokenIds[0] = 3;
+        tokenIds[1] = 4;
+        originalToken.setApprovalForAll(address(originalDAO), true);
+        originalDAO.joinFork(tokenIds, new uint256[](0), '');
+
+        // unpause auction, which calls mint, which should work if token's _currentNounId is set correctly
+        changePrank(originalNouner);
+        uint256 unpauseAuctionPropId = proposeToForkAndRollToVoting(address(forkAuction), 0, 'unpause()', '');
+        forkDAO.castVote(unpauseAuctionPropId, 1);
+        queueAndExecute(unpauseAuctionPropId);
+
+        // if the unpause tx fails because of a failed mint, auction house pauses itself
+        assertFalse(forkAuction.paused());
+        assertEq(getAuction(forkAuction).nounId, 5);
     }
 }
 

--- a/packages/nouns-contracts/test/foundry/governance/fork/ForkingEndToEnd.t.sol
+++ b/packages/nouns-contracts/test/foundry/governance/fork/ForkingEndToEnd.t.sol
@@ -318,7 +318,7 @@ contract ForkDAO_PostFork_NewOGNounsJoin is ForkDAOBase {
         bidAndSettleOriginalAuction(joiningNouner);
 
         // join the fork with new noun IDs
-        changePrank(joiningNouner);
+        vm.startPrank(joiningNouner);
         uint256[] memory tokenIds = new uint256[](2);
         tokenIds[0] = 3;
         tokenIds[1] = 4;


### PR DESCRIPTION
Fixes this spearbit audit issue: https://github.com/spearbit-audits/review-nouns/issues/9

TLDR of the bug:

1. execute a fork
2. buy new nouns on the original auction
3. join the fork with those new nouns
4. attempt to unpause the fork auction house

the bug is such that the fork auction house can't unpause, because minting fails, because we're trying to mint an ID that was already minted through fork joining.

the fix is when nouns join a fork, to make sure the next ID the fork auction house will use is always higher than highest noun ID to ever join.