### PR TITLE
fork dao: block gov & quit until forking period is over

### DIFF
--- a/packages/nouns-contracts/contracts/governance/fork/newdao/governance/NounsDAOLogicV1Fork.sol
+++ b/packages/nouns-contracts/contracts/governance/fork/newdao/governance/NounsDAOLogicV1Fork.sol
@@ -339,13 +339,18 @@ contract NounsDAOLogicV1Fork is UUPSUpgradeable, ReentrancyGuardUpgradeable, Nou
 
     /**
      * @notice Internal function that reverts if the governance is not active yet. Governance becomes active as soon as
-     * one of these conditions is met:
+     * the forking period ended and one of these conditions is met:
      * 1. All tokens are claimed
      * 2. The delayed governance expiration timestamp is reached
      */
     function checkGovernanceActive() internal view {
-        if (block.timestamp < delayedGovernanceExpirationTimestamp && nouns.remainingTokensToClaim() > 0)
+        if (block.timestamp < nouns.forkingPeriodEndTimestamp()) {
             revert WaitingForTokensToClaimOrExpiration();
+        }
+
+        if (block.timestamp < delayedGovernanceExpirationTimestamp && nouns.remainingTokensToClaim() > 0) {
+            revert WaitingForTokensToClaimOrExpiration();
+        }
     }
 
     /**

--- a/packages/nouns-contracts/contracts/governance/fork/newdao/governance/NounsDAOLogicV1Fork.sol
+++ b/packages/nouns-contracts/contracts/governance/fork/newdao/governance/NounsDAOLogicV1Fork.sol
@@ -105,6 +105,7 @@ import { ReentrancyGuardUpgradeable } from '@openzeppelin/contracts-upgradeable/
 contract NounsDAOLogicV1Fork is UUPSUpgradeable, ReentrancyGuardUpgradeable, NounsDAOStorageV1Fork, NounsDAOEventsFork {
     error AdminOnly();
     error WaitingForTokensToClaimOrExpiration();
+    error GovernanceBlockedDuringForkingPeriod();
     error QuitETHTransferFailed();
     error QuitERC20TransferFailed();
 
@@ -345,7 +346,7 @@ contract NounsDAOLogicV1Fork is UUPSUpgradeable, ReentrancyGuardUpgradeable, Nou
      */
     function checkGovernanceActive() internal view {
         if (block.timestamp < nouns.forkingPeriodEndTimestamp()) {
-            revert WaitingForTokensToClaimOrExpiration();
+            revert GovernanceBlockedDuringForkingPeriod();
         }
 
         if (block.timestamp < delayedGovernanceExpirationTimestamp && nouns.remainingTokensToClaim() > 0) {

--- a/packages/nouns-contracts/contracts/governance/fork/newdao/governance/NounsTokenForkLike.sol
+++ b/packages/nouns-contracts/contracts/governance/fork/newdao/governance/NounsTokenForkLike.sol
@@ -18,4 +18,6 @@ interface NounsTokenForkLike {
     function ownerOf(uint256 tokenId) external view returns (address owner);
 
     function remainingTokensToClaim() external view returns (uint256);
+
+    function forkingPeriodEndTimestamp() external view returns (uint256);
 }

--- a/packages/nouns-contracts/test/foundry/NounsDAOLogicV3/UpgradeToDAOV3ForkMainnetTest.t.sol
+++ b/packages/nouns-contracts/test/foundry/NounsDAOLogicV3/UpgradeToDAOV3ForkMainnetTest.t.sol
@@ -221,6 +221,10 @@ contract UpgradeToDAOV3ForkMainnetTest is Test {
         signatures = [''];
         calldatas = [bytes('')];
 
+        vm.expectRevert(NounsDAOLogicV1Fork.GovernanceBlockedDuringForkingPeriod.selector);
+        forkDao.propose(targets, values, signatures, calldatas, 'new prop');
+
+        vm.warp(block.timestamp + 7 days);
         vm.expectRevert(NounsDAOLogicV1Fork.WaitingForTokensToClaimOrExpiration.selector);
         forkDao.propose(targets, values, signatures, calldatas, 'new prop');
 

--- a/packages/nouns-contracts/test/foundry/governance/fork/ForkingEndToEnd.t.sol
+++ b/packages/nouns-contracts/test/foundry/governance/fork/ForkingEndToEnd.t.sol
@@ -80,7 +80,13 @@ contract ForkingHappyFlowTest is DeployUtilsFork {
         forkToken.claimFromEscrow(tokensInEscrow2);
         vm.roll(block.number + 1);
 
-        // Demonstrating we're able to submit a proposal now that all claimable tokens have been claimed.
+        // Demonstrating we're able to submit a proposal now that all claimable tokens have been claimed and
+        // forking period is over
+        vm.startPrank(nounerInEscrow1);
+        vm.expectRevert(NounsDAOLogicV1Fork.WaitingForTokensToClaimOrExpiration.selector);
+        proposeToFork(makeAddr('target'), 0, 'signature', 'data');
+
+        vm.warp(forkToken.forkingPeriodEndTimestamp());
         vm.startPrank(nounerInEscrow1);
         proposeToFork(makeAddr('target'), 0, 'signature', 'data');
 
@@ -201,6 +207,8 @@ abstract contract ForkDAOBase is DeployUtilsFork {
         forkToken.claimFromEscrow(tokenIds);
         vm.stopPrank();
         vm.roll(block.number + 1);
+
+        vm.warp(forkToken.forkingPeriodEndTimestamp());
     }
 
     function bidAndSettleAuction() internal {

--- a/packages/nouns-contracts/test/foundry/governance/fork/ForkingEndToEnd.t.sol
+++ b/packages/nouns-contracts/test/foundry/governance/fork/ForkingEndToEnd.t.sol
@@ -54,16 +54,23 @@ contract ForkingHappyFlowTest is DeployUtilsFork {
         // of that is 8 ETH.
         assertEqUint(forkTreasuryAddress.balance, 8 ether);
 
-        // Asserting that delayed governance is working - no one should be able to propose until all fork tokens have
-        // been claimed, or until the delay period expires.
-        // Later in this test we make sure we CAN propose once all tokens have been claimed.
-        vm.expectRevert(abi.encodeWithSelector(NounsDAOLogicV1Fork.WaitingForTokensToClaimOrExpiration.selector));
+        // Governance is blocked during forking period
+        vm.expectRevert(NounsDAOLogicV1Fork.GovernanceBlockedDuringForkingPeriod.selector);
         proposeToFork(makeAddr('target'), 0, 'signature', 'data');
 
         // Two additional Nouners join the fork during the forking period.
         // This should grow the ETH balance sent from OG DAO to fork DAO.
         joinFork(nounerForkJoiner1);
         joinFork(nounerForkJoiner2);
+
+        // Forking period finished
+        vm.warp(forkToken.forkingPeriodEndTimestamp());
+
+        // Asserting that delayed governance is working - no one should be able to propose until all fork tokens have
+        // been claimed, or until the delay period expires.
+        // Later in this test we make sure we CAN propose once all tokens have been claimed.
+        vm.expectRevert(NounsDAOLogicV1Fork.WaitingForTokensToClaimOrExpiration.selector);
+        proposeToFork(makeAddr('target'), 0, 'signature', 'data');
 
         // Asserting the expected ETH amount was sent. We're now at two thirds of OG Nouns forking, so we expect
         // two thirds of the ETH to be sent, which is 16 out of the original 24.
@@ -82,11 +89,6 @@ contract ForkingHappyFlowTest is DeployUtilsFork {
 
         // Demonstrating we're able to submit a proposal now that all claimable tokens have been claimed and
         // forking period is over
-        vm.startPrank(nounerInEscrow1);
-        vm.expectRevert(NounsDAOLogicV1Fork.WaitingForTokensToClaimOrExpiration.selector);
-        proposeToFork(makeAddr('target'), 0, 'signature', 'data');
-
-        vm.warp(forkToken.forkingPeriodEndTimestamp());
         vm.startPrank(nounerInEscrow1);
         proposeToFork(makeAddr('target'), 0, 'signature', 'data');
 

--- a/packages/nouns-contracts/test/foundry/governance/fork/NounsDAOLogicV1Fork.t.sol
+++ b/packages/nouns-contracts/test/foundry/governance/fork/NounsDAOLogicV1Fork.t.sol
@@ -220,7 +220,7 @@ contract NounsDAOLogicV1Fork_DelayedGovernance_Test is ForkWithEscrow {
         // mining one block so proposer prior votes getter sees their tokens.
         vm.roll(block.number + 1);
 
-        vm.expectRevert(NounsDAOLogicV1Fork.WaitingForTokensToClaimOrExpiration.selector);
+        vm.expectRevert(NounsDAOLogicV1Fork.GovernanceBlockedDuringForkingPeriod.selector);
         propose();
     }
 
@@ -239,7 +239,7 @@ contract NounsDAOLogicV1Fork_DelayedGovernance_Test is ForkWithEscrow {
 
         token.setApprovalForAll(address(dao), true);
 
-        vm.expectRevert(NounsDAOLogicV1Fork.WaitingForTokensToClaimOrExpiration.selector);
+        vm.expectRevert(NounsDAOLogicV1Fork.GovernanceBlockedDuringForkingPeriod.selector);
         dao.quit(tokens);
     }
 

--- a/packages/nouns-contracts/test/foundry/helpers/NounsDAOLogicSharedBase.t.sol
+++ b/packages/nouns-contracts/test/foundry/helpers/NounsDAOLogicSharedBase.t.sol
@@ -12,6 +12,7 @@ import { NounsToken } from '../../../contracts/NounsToken.sol';
 import { NounsSeeder } from '../../../contracts/NounsSeeder.sol';
 import { IProxyRegistry } from '../../../contracts/external/opensea/IProxyRegistry.sol';
 import { NounsDAOExecutor } from '../../../contracts/governance/NounsDAOExecutor.sol';
+import { NounsTokenForkLike } from '../../../contracts/governance/fork/newdao/governance/NounsTokenForkLike.sol';
 import { Utils } from './Utils.sol';
 
 abstract contract NounsDAOLogicSharedBaseTest is Test, DeployUtilsFork {
@@ -125,6 +126,8 @@ abstract contract NounsDAOLogicSharedBaseTest is Test, DeployUtilsFork {
         dao._setProposalThresholdBPS(proposalThresholdBPS);
         dao._setQuorumVotesBPS(1000);
         vm.stopPrank();
+
+        vm.warp(NounsTokenForkLike(tokenAddress).forkingPeriodEndTimestamp());
 
         return NounsDAOLogicV1(daoAddress);
     }


### PR DESCRIPTION
Mitigation for: https://github.com/spearbit-audits/review-nouns/issues/26

Before this change, token holders who escrowed and claimed their tokens could quit the fork dao if they all immediately claimed because the `checkGovernanceActive` function would return true.

This changes blocks proposals & quit until the forking period is over.