### PR TITLE
fix timestamp check in claimDuringForkPeriod

### DIFF
--- a/packages/nouns-contracts/contracts/governance/fork/newdao/token/NounsTokenFork.sol
+++ b/packages/nouns-contracts/contracts/governance/fork/newdao/token/NounsTokenFork.sol
@@ -167,7 +167,7 @@ contract NounsTokenFork is INounsTokenFork, OwnableUpgradeable, ERC721Checkpoint
         uint256 currentNounId = _currentNounId;
         uint256 maxNounId = 0;
         if (msg.sender != escrow.dao()) revert OnlyOriginalDAO();
-        if (block.timestamp > forkingPeriodEndTimestamp) revert OnlyDuringForkingPeriod();
+        if (block.timestamp >= forkingPeriodEndTimestamp) revert OnlyDuringForkingPeriod();
 
         for (uint256 i = 0; i < tokenIds.length; i++) {
             uint256 nounId = tokenIds[i];

--- a/packages/nouns-contracts/test/foundry/governance/fork/NounsTokenFork.t.sol
+++ b/packages/nouns-contracts/test/foundry/governance/fork/NounsTokenFork.t.sol
@@ -79,7 +79,7 @@ contract NounsTokenFork_ClaimDuringForkPeriod_Test is NounsTokenForkBase {
     }
 
     function test_givenForkingPeriodExpired_reverts() public {
-        vm.warp(token.forkingPeriodEndTimestamp() + 1);
+        vm.warp(token.forkingPeriodEndTimestamp());
 
         vm.prank(originalDAO);
         vm.expectRevert(abi.encodeWithSelector(NounsTokenFork.OnlyDuringForkingPeriod.selector));


### PR DESCRIPTION
now it matches the check in NounsDAOV3Fork.isForkPeriodActive

otherwise it allows the OG DAO to claim in the last second

fix for: https://github.com/spearbit-audits/review-nouns/issues/40