### PR TITLE
audit fix: transfer noun to new timelock

### DIFF
--- a/packages/nouns-contracts/script/ProposeTimelockMigrationCleanupMainnet.s.sol
+++ b/packages/nouns-contracts/script/ProposeTimelockMigrationCleanupMainnet.s.sol
@@ -50,7 +50,7 @@ contract ProposeTimelockMigrationCleanupMainnet is Script {
         address lilNouns,
         string memory description
     ) internal returns (uint256 proposalId) {
-        uint8 numTxs = 5;
+        uint8 numTxs = 6;
         address[] memory targets = new address[](numTxs);
         uint256[] memory values = new uint256[](numTxs);
         string[] memory signatures = new string[](numTxs);
@@ -90,6 +90,13 @@ contract ProposeTimelockMigrationCleanupMainnet is Script {
         values[i] = 0;
         signatures[i] = 'setApprovalForAll(address,bool)';
         calldatas[i] = abi.encode(timelockV2, true);
+
+        // Transfer DAO-owned Nouns to timelockV2
+        i++;
+        targets[i] = nounsToken;
+        values[i] = 0;
+        signatures[i] = 'transferFrom(address,address,uint256)';
+        calldatas[i] = abi.encode(timelockV1, timelockV2, 687);
 
         proposalId = daoProxy.proposeOnTimelockV1(targets, values, signatures, calldatas, description);
     }

--- a/packages/nouns-contracts/test/foundry/NounsDAOLogicV3/UpgradeToDAOV3ForkMainnetTest.t.sol
+++ b/packages/nouns-contracts/test/foundry/NounsDAOLogicV3/UpgradeToDAOV3ForkMainnetTest.t.sol
@@ -259,6 +259,8 @@ contract UpgradeToDAOV3ForkMainnetTest is Test {
         assertEq(address(NOUNS_TIMELOCK_V1_MAINNET).balance, 0);
         assertEq(address(timelockV2).balance, expectedV2Balance);
         assertTrue(IERC721(LILNOUNS_MAINNET).isApprovedForAll(address(NOUNS_TIMELOCK_V1_MAINNET), address(timelockV2)));
+        assertEq(nouns.balanceOf(address(NOUNS_TIMELOCK_V1_MAINNET)), 0);
+        assertEq(nouns.ownerOf(687), address(timelockV2));
     }
 
     function test_ensChange_nounsDotETHResolvesBothWaysWithTimelockV2() public {


### PR DESCRIPTION
spearbit issue: https://github.com/spearbit-audits/review-nouns/issues/33