### PR TITLE
move token-buyer ownership transfer to cleanup proposal

### DIFF
--- a/packages/nouns-contracts/script/ProposeDAOV3UpgradeMainnet.s.sol
+++ b/packages/nouns-contracts/script/ProposeDAOV3UpgradeMainnet.s.sol
@@ -16,9 +16,9 @@ contract ProposeDAOV3UpgradeMainnet is Script {
     uint256 public constant FORK_THRESHOLD_BPS = 2000;
 
     address public constant STETH_MAINNET = 0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84;
-    address public constant TOKEN_BUYER_MAINNET = 0x4f2aCdc74f6941390d9b1804faBc3E780388cfe5;
-    address public constant PAYER_MAINNET = 0xd97Bcd9f47cEe35c0a9ec1dc40C1269afc9E8E1D;
     address public constant AUCTION_HOUSE_PROXY_MAINNET = 0x830BD73E4184ceF73443C15111a1DF14e495C706;
+    address public constant NOUNS_TOKEN_MAINNET = 0x9C8fF314C9Bc7F6e59A9d9225Fb22946427eDC03;
+    address public constant DESCRIPTOR_MAINNET = 0x6229c811D04501523C6058bfAAc29c91bb586268;
 
     function run() public returns (uint256 proposalId) {
         uint256 proposerKey = vm.envUint('PROPOSER_KEY');
@@ -104,18 +104,6 @@ contract ProposeDAOV3UpgradeMainnet is Script {
         calldatas[i] = '';
 
         i++;
-        targets[i] = TOKEN_BUYER_MAINNET;
-        values[i] = 0;
-        signatures[i] = 'transferOwnership(address)';
-        calldatas[i] = abi.encode(timelockV2);
-
-        i++;
-        targets[i] = PAYER_MAINNET;
-        values[i] = 0;
-        signatures[i] = 'transferOwnership(address)';
-        calldatas[i] = abi.encode(timelockV2);
-
-        i++;
         targets[i] = AUCTION_HOUSE_PROXY_MAINNET;
         values[i] = 0;
         signatures[i] = 'transferOwnership(address)';
@@ -133,6 +121,21 @@ contract ProposeDAOV3UpgradeMainnet is Script {
         signatures[i] = 'transferEntireBalance(address,address)';
         calldatas[i] = abi.encode(STETH_MAINNET, timelockV2);
 
+        // Change nouns token owner
+        i++;
+        targets[i] = NOUNS_TOKEN_MAINNET;
+        values[i] = 0;
+        signatures[i] = 'transferOwnership(address)';
+        calldatas[i] = abi.encode(timelockV2);
+
+        // Change descriptor owner
+        i++;
+        targets[i] = DESCRIPTOR_MAINNET;
+        values[i] = 0;
+        signatures[i] = 'transferOwnership(address)';
+        calldatas[i] = abi.encode(timelockV2);
+
+        // This must be the last transaction, because starting now, execution will be from timelockV2
         i++;
         targets[i] = address(daoProxy);
         values[i] = 0;

--- a/packages/nouns-contracts/script/ProposeTimelockMigrationCleanupMainnet.s.sol
+++ b/packages/nouns-contracts/script/ProposeTimelockMigrationCleanupMainnet.s.sol
@@ -15,8 +15,9 @@ contract ProposeTimelockMigrationCleanupMainnet is Script {
     address public constant NOUNS_TIMELOCK_V1_MAINNET = 0x0BC3807Ec262cB779b38D65b38158acC3bfedE10;
     address public constant NOUNS_TOKEN_MAINNET = 0x9C8fF314C9Bc7F6e59A9d9225Fb22946427eDC03;
     address public constant AUCTION_HOUSE_PROXY_ADMIN_MAINNET = 0xC1C119932d78aB9080862C5fcb964029f086401e;
-    address public constant DESCRIPTOR_MAINNET = 0x6229c811D04501523C6058bfAAc29c91bb586268;
     address public constant LILNOUNS_MAINNET = 0x4b10701Bfd7BFEdc47d50562b76b436fbB5BdB3B;
+    address public constant TOKEN_BUYER_MAINNET = 0x4f2aCdc74f6941390d9b1804faBc3E780388cfe5;
+    address public constant PAYER_MAINNET = 0xd97Bcd9f47cEe35c0a9ec1dc40C1269afc9E8E1D;
 
     function run() public returns (uint256 proposalId) {
         uint256 proposerKey = vm.envUint('PROPOSER_KEY');
@@ -30,7 +31,6 @@ contract ProposeTimelockMigrationCleanupMainnet is Script {
             NOUNS_TIMELOCK_V1_MAINNET,
             timelockV2,
             NOUNS_TOKEN_MAINNET,
-            DESCRIPTOR_MAINNET,
             AUCTION_HOUSE_PROXY_ADMIN_MAINNET,
             LILNOUNS_MAINNET,
             description
@@ -45,7 +45,6 @@ contract ProposeTimelockMigrationCleanupMainnet is Script {
         address timelockV1,
         address timelockV2,
         address nounsToken,
-        address descriptor,
         address auctionHouseProxyAdmin,
         address lilNouns,
         string memory description
@@ -56,22 +55,8 @@ contract ProposeTimelockMigrationCleanupMainnet is Script {
         string[] memory signatures = new string[](numTxs);
         bytes[] memory calldatas = new bytes[](numTxs);
 
-        // Change nouns token owner
-        uint256 i = 0;
-        targets[i] = nounsToken;
-        values[i] = 0;
-        signatures[i] = 'transferOwnership(address)';
-        calldatas[i] = abi.encode(timelockV2);
-
-        // Change descriptor owner
-        i++;
-        targets[i] = descriptor;
-        values[i] = 0;
-        signatures[i] = 'transferOwnership(address)';
-        calldatas[i] = abi.encode(timelockV2);
-
         // Change auction house proxy admin owner
-        i++;
+        uint256 i = 0;
         targets[i] = auctionHouseProxyAdmin;
         values[i] = 0;
         signatures[i] = 'transferOwnership(address)';
@@ -97,6 +82,20 @@ contract ProposeTimelockMigrationCleanupMainnet is Script {
         values[i] = 0;
         signatures[i] = 'transferFrom(address,address,uint256)';
         calldatas[i] = abi.encode(timelockV1, timelockV2, 687);
+
+        // Transfer ownership of TokenBuyer
+        i++;
+        targets[i] = TOKEN_BUYER_MAINNET;
+        values[i] = 0;
+        signatures[i] = 'transferOwnership(address)';
+        calldatas[i] = abi.encode(timelockV2);
+
+        // Transfer ownership of Payer
+        i++;
+        targets[i] = PAYER_MAINNET;
+        values[i] = 0;
+        signatures[i] = 'transferOwnership(address)';
+        calldatas[i] = abi.encode(timelockV2);
 
         proposalId = daoProxy.proposeOnTimelockV1(targets, values, signatures, calldatas, description);
     }

--- a/packages/nouns-contracts/test/foundry/NounsDAOLogicV3/UpgradeToDAOV3ForkMainnetTest.t.sol
+++ b/packages/nouns-contracts/test/foundry/NounsDAOLogicV3/UpgradeToDAOV3ForkMainnetTest.t.sol
@@ -172,14 +172,6 @@ contract UpgradeToDAOV3ForkMainnetTest is Test {
         assertEq(daoV3.voteSnapshotBlockSwitchProposalId(), 299);
     }
 
-    function test_TokenBuyer_changedOwner() public {
-        assertEq(IOwnable(TOKEN_BUYER_MAINNET).owner(), address(timelockV2));
-    }
-
-    function test_Payer_changedOwner() public {
-        assertEq(IOwnable(PAYER_MAINNET).owner(), address(timelockV2));
-    }
-
     function test_transfersAllstETH() public {
         assertEq(IERC20(STETH_MAINNET).balanceOf(address(NOUNS_TIMELOCK_V1_MAINNET)), 1);
         assertEq(IERC20(STETH_MAINNET).balanceOf(address(timelockV2)), STETH_BALANCE - 1);
@@ -265,6 +257,8 @@ contract UpgradeToDAOV3ForkMainnetTest is Test {
         assertTrue(IERC721(LILNOUNS_MAINNET).isApprovedForAll(address(NOUNS_TIMELOCK_V1_MAINNET), address(timelockV2)));
         assertEq(nouns.balanceOf(address(NOUNS_TIMELOCK_V1_MAINNET)), 0);
         assertEq(nouns.ownerOf(687), address(timelockV2));
+        assertEq(IOwnable(TOKEN_BUYER_MAINNET).owner(), address(timelockV2));
+        assertEq(IOwnable(PAYER_MAINNET).owner(), address(timelockV2));
     }
 
     function test_ensChange_nounsDotETHResolvesBothWaysWithTimelockV2() public {


### PR DESCRIPTION
fix for: https://github.com/spearbit-audits/review-nouns/issues/54

the assumption is that this followup proposal will be created shortly after the main upgrade proposal executes.
this will allow any existing USDC proposals to execute via timelockV1. new USDC proposals create after the upgrade proposal execution will be queued on timelock v2.
the cleanup proposal will change the ownership of token buyer to timelock v2 so new proposals should also be able to execute correctly