### PR TITLE
split withdrawDAONounsFromEscrow to 2 functions

### DIFF
--- a/packages/nouns-contracts/contracts/governance/NounsDAOInterfaces.sol
+++ b/packages/nouns-contracts/contracts/governance/NounsDAOInterfaces.sol
@@ -255,6 +255,9 @@ contract NounsDAOEventsV3 is NounsDAOEventsV2 {
 
     /// @notice Emitted when the DAO withdraws nouns from the fork escrow after a fork has been executed
     event DAOWithdrawNounsFromEscrow(uint256[] tokenIds, address to);
+
+    /// @notice Emitted when withdrawing nouns from escrow increases adjusted total supply
+    event DAONounsSupplyIncreasedFromEscrow(uint256 numTokens, address to);
 }
 
 contract NounsDAOProxyStorage {

--- a/packages/nouns-contracts/contracts/governance/NounsDAOLogicV3.sol
+++ b/packages/nouns-contracts/contracts/governance/NounsDAOLogicV3.sol
@@ -507,13 +507,22 @@ contract NounsDAOLogicV3 is NounsDAOStorageV3, NounsDAOEventsV3 {
     }
 
     /**
-     * @notice Withdraws nouns from the fork escrow after the fork has been executed
+     * @notice Withdraws nouns from the fork escrow to the treasury after the fork has been executed
+     * @dev Only the DAO can call this function
+     * @param tokenIds the tokenIds to withdraw
+     */
+    function withdrawDAONounsFromEscrowToTreasury(uint256[] calldata tokenIds) external {
+        ds.withdrawDAONounsFromEscrowToTreasury(tokenIds);
+    }
+
+    /**
+     * @notice Withdraws nouns from the fork escrow after the fork has been executed to an address other than the treasury
      * @dev Only the DAO can call this function
      * @param tokenIds the tokenIds to withdraw
      * @param to the address to send the nouns to
      */
-    function withdrawDAONounsFromEscrow(uint256[] calldata tokenIds, address to) external {
-        ds.withdrawDAONounsFromEscrow(tokenIds, to);
+    function withdrawDAONounsFromEscrowIncreasingTotalSupply(uint256[] calldata tokenIds, address to) external {
+        ds.withdrawDAONounsFromEscrowIncreasingTotalSupply(tokenIds, to);
     }
 
     /**


### PR DESCRIPTION
fixes: https://github.com/spearbit-audits/review-nouns/issues/61

this is in order to make it clearer that when withdrawing nouns to an address other than the treasury it will increase the total supply, which then affects quorum, proposal threshold, and fork calculations