### PR TITLE
added commands and instructions for running webapp from root shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,24 @@ yarn lint
 ```sh
 yarn format
 ```
+
+## Quickstart - Webapp
+
+Using these commands you can get your own version of Nouns deployed to your localhost, and run a webapp locally which accesses them.
+See `packages/nouns-webapp/README.md` for more details.
+
+In the first shell:
+
+```sh
+# Start local simnet
+yarn task:run-local
+```
+
+In the second shell:
+
+```sh
+# Copy local example environment file
+yarn copy-env
+# Start local development
+yarn start
+```

--- a/package.json
+++ b/package.json
@@ -8,7 +8,10 @@
     "clean": "lerna run --parallel clean",
     "prepare": "lerna run prepare --scope=@nouns/{assets,contracts,sdk}",
     "lint": "eslint 'packages/**/*.ts' --fix",
-    "format": "NODE_OPTIONS=--max_old_space_size=16384 prettier --write 'packages/**/*.{ts(x)?,sol,md,css,json}' '!**/typechain/**'"
+    "format": "NODE_OPTIONS=--max_old_space_size=16384 prettier --write 'packages/**/*.{ts(x)?,sol,md,css,json}' '!**/typechain/**'",
+    "task:run-local": "cd packages/nouns-contracts && yarn task:run-local",
+    "copy-env": "cd packages/nouns-webapp && cp .env.example.local .env",
+    "start": "cd packages/nouns-webapp && yarn start"
   },
   "devDependencies": {
     "@types/chai": "^4.2.15",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13829,9 +13829,9 @@ globby@^9.2.0:
     pify "^4.0.1"
     slash "^2.0.0"
 
-"gluegun@git+https://github.com/edgeandnode/gluegun.git#v4.3.1-pin-colors-dep":
+"gluegun@https://github.com/edgeandnode/gluegun#v4.3.1-pin-colors-dep":
   version "4.3.1"
-  resolved "git+https://github.com/edgeandnode/gluegun.git#b34b9003d7bf556836da41b57ef36eb21570620a"
+  resolved "https://github.com/edgeandnode/gluegun#b34b9003d7bf556836da41b57ef36eb21570620a"
   dependencies:
     apisauce "^1.0.1"
     app-module-path "^2.2.0"


### PR DESCRIPTION
It can get annoying to `cd` in several terminals to the proper directory.

This commit adds commands to the root yarn package to save a few steps there.