### PR TITLE
add block info to candidate signatures in the subgraph

### DIFF
--- a/packages/nouns-subgraph/schema.graphql
+++ b/packages/nouns-subgraph/schema.graphql
@@ -520,6 +520,12 @@ type ProposalCandidateSignature @entity {
 
   "Whether this signature has been canceled"
   canceled: Boolean!
+
+  "The signature's creation timestamp"
+  createdTimestamp: BigInt!
+
+  "The signature's creation block"
+  createdBlock: BigInt!
 }
 
 type ProposalFeedback @entity(immutable: true) {

--- a/packages/nouns-subgraph/src/nouns-dao-data.ts
+++ b/packages/nouns-subgraph/src/nouns-dao-data.ts
@@ -121,6 +121,8 @@ export function handleSignatureAdded(event: SignatureAdded): void {
   candidateSig.encodedProposalHash = event.params.encodedPropHash;
   candidateSig.sigDigest = event.params.sigDigest;
   candidateSig.reason = event.params.reason;
+  candidateSig.createdBlock = event.block.number;
+  candidateSig.createdTimestamp = event.block.timestamp;
 
   candidateSig.save();
 }

--- a/packages/nouns-subgraph/tests/nouns-dao-data.test.ts
+++ b/packages/nouns-subgraph/tests/nouns-dao-data.test.ts
@@ -116,6 +116,8 @@ describe('nouns-dao-data', () => {
         encodedProposalHash,
         sigDigest,
         reason,
+        blockNumber,
+        blockTimestamp,
       );
 
       handleSignatureAdded(event);
@@ -140,6 +142,8 @@ describe('nouns-dao-data', () => {
       assert.bytesEquals(signature.sigDigest, sigDigest);
       assert.stringEquals(signature.reason, reason);
       assert.booleanEquals(signature.canceled, false);
+      assert.bigIntEquals(signature.createdBlock, blockNumber);
+      assert.bigIntEquals(signature.createdTimestamp, blockTimestamp);
     });
 
     test('skips signature if encodedProposalHash does not match latest version', () => {
@@ -158,6 +162,8 @@ describe('nouns-dao-data', () => {
         differentEncodedProposalHash,
         sigDigest,
         reason,
+        blockNumber,
+        blockTimestamp,
       );
 
       handleSignatureAdded(event);

--- a/packages/nouns-subgraph/tests/utils.ts
+++ b/packages/nouns-subgraph/tests/utils.ts
@@ -396,8 +396,12 @@ export function createSignatureAddedEvent(
   encodedPropHash: Bytes,
   sigDigest: Bytes,
   reason: string,
+  blockNumber: BigInt,
+  blockTimestamp: BigInt,
 ): SignatureAdded {
   let newEvent = changetype<SignatureAdded>(newMockEvent());
+  newEvent.block.timestamp = blockTimestamp;
+  newEvent.block.number = blockNumber;
 
   newEvent.parameters.push(new ethereum.EventParam('signer', ethereum.Value.fromAddress(signer)));
   newEvent.parameters.push(new ethereum.EventParam('sig', ethereum.Value.fromBytes(sig)));


### PR DESCRIPTION
Add `createdBlock` (blockNumber) and `createdTimestamp` (blockTimestamp) fields for candidate signatures.

In the previous PR I used `blockTimestamp` for votes, as there was already a `blockNumber`, however here followed the naming of newer entities.  Unsure what's best, but happy to change it if you have some conventions for it.