### PR TITLE
add number to Candidates [subgraph]

### DIFF
--- a/packages/nouns-subgraph/schema.graphql
+++ b/packages/nouns-subgraph/schema.graphql
@@ -408,6 +408,9 @@ type Governance @entity {
 
   "The proposal ID from which vote snapshots are taken at vote start instead of proposal creation"
   voteSnapshotBlockSwitchProposalId: BigInt!
+
+  "Number of candidates created"
+  candidates: BigInt!
 }
 
 type DynamicQuorumParams @entity {
@@ -466,6 +469,9 @@ type ProposalCandidate @entity {
 
   "This candidate's versions"
   versions: [ProposalCandidateVersion!]! @derivedFrom(field: "proposal")
+
+  "This candidate's number"
+  number: BigInt!
 }
 
 type ProposalCandidateVersion @entity(immutable: true) {

--- a/packages/nouns-subgraph/src/nouns-dao-data.ts
+++ b/packages/nouns-subgraph/src/nouns-dao-data.ts
@@ -11,6 +11,7 @@ import {
 import { ProposalCandidateContent, ProposalCandidateVersion } from './types/schema';
 import {
   candidateID,
+  getCandidateIndex,
   getOrCreateCandidateFeedback,
   getOrCreateDelegate,
   getOrCreateProposalCandidate,
@@ -33,6 +34,7 @@ export function handleProposalCandidateCreated(event: ProposalCandidateCreated):
   candidate.lastUpdatedTimestamp = event.block.timestamp;
   candidate.lastUpdatedBlock = event.block.number;
   candidate.canceled = false;
+  candidate.number = getCandidateIndex();
 
   const version = captureProposalCandidateVersion(
     event.transaction.hash.toHexString(),

--- a/packages/nouns-subgraph/src/utils/helpers.ts
+++ b/packages/nouns-subgraph/src/utils/helpers.ts
@@ -138,6 +138,7 @@ export function getGovernanceEntity(): Governance {
     governance.delegatedVotes = BIGINT_ZERO;
     governance.proposalsQueued = BIGINT_ZERO;
     governance.voteSnapshotBlockSwitchProposalId = BIGINT_ZERO;
+    governance.candidates = BIGINT_ZERO;
   }
 
   return governance as Governance;
@@ -177,7 +178,12 @@ export function getOrCreateProposalCandidate(id: string): ProposalCandidate {
   let candidate = ProposalCandidate.load(id);
   if (candidate == null) {
     candidate = new ProposalCandidate(id);
+
+    const governance = getGovernanceEntity();
+    governance.candidates = governance.candidates.plus(BIGINT_ONE);
+    governance.save();
   }
+
   return candidate;
 }
 
@@ -231,6 +237,11 @@ export function getOrCreateFork(id: BigInt): Fork {
     fork.tokensForkingCount = 0;
   }
   return fork;
+}
+
+export function getCandidateIndex(): BigInt {
+  const governance = getGovernanceEntity();
+  return governance.candidates;
 }
 
 export function candidateID(proposer: Address, slug: string): string {

--- a/packages/nouns-subgraph/tests/nouns-dao-data.test.ts
+++ b/packages/nouns-subgraph/tests/nouns-dao-data.test.ts
@@ -84,6 +84,7 @@ describe('nouns-dao-data', () => {
       assert.bytesEquals(txHash, candidate.createdTransactionHash);
       assert.bigIntEquals(blockTimestamp, candidate.createdTimestamp);
       assert.bigIntEquals(blockNumber, candidate.createdBlock);
+      assert.bigIntEquals(BigInt.fromI32(1), candidate.number);
 
       const version = ProposalCandidateVersion.load(candidate.latestVersion)!;
       assert.stringEquals(candidate.id, version.proposal);
@@ -176,6 +177,44 @@ describe('nouns-dao-data', () => {
         event.transaction.hash.toHexString().concat('-').concat(event.logIndex.toString()),
       );
       assert.assertNull(signature);
+    });
+
+    test('save a proposal candidade includes candidate index', () => {
+      const candidate = ProposalCandidate.load(
+        candidateProposer.toHexString().concat('-').concat(slug),
+      )!;
+      assert.stringEquals(candidateProposer.toHexString(), candidate.proposer.toHexString());
+      assert.stringEquals(slug, candidate.slug);
+      assert.bytesEquals(txHash, candidate.createdTransactionHash);
+      assert.bigIntEquals(blockTimestamp, candidate.createdTimestamp);
+      assert.bigIntEquals(blockNumber, candidate.createdBlock);
+      assert.bigIntEquals(BigInt.fromI32(1), candidate.number);
+
+      const newSlug = 'new slug';
+
+      // save new one
+      const event = createProposalCandidateCreatedEvent(
+        txHash,
+        logIndex,
+        blockTimestamp,
+        blockNumber,
+        candidateProposer,
+        targets,
+        values,
+        signatures,
+        calldatas,
+        description,
+        newSlug,
+        encodedProposalHash,
+      );
+
+      handleProposalCandidateCreated(event);
+
+      const candidate2 = ProposalCandidate.load(
+        candidateProposer.toHexString().concat('-').concat(newSlug),
+      )!;
+
+      assert.bigIntEquals(BigInt.fromI32(2), candidate2.number);
     });
   });
 });


### PR DESCRIPTION
This PR adds a `number` field to the ProposalCandidate graph entity. 

The idea behind this change is that the current candidate ID - `proposer-slug` - generates really big URLs that make it a bit hard to share candidate links around or even quickly open one the same way you do with props (https:..noun-client/proposal/X)

Here are a couple of candidate URLs as we have them today:

- https://www.nouns.camp/candidates/spec-the--to-eliminate-the-put-requesting-feedback--073f0dc58e9989c827ba5b7b35570b7315652e63
- https://www.nouns.camp/candidates/placeholder-nouns--a-movie---chapter-3-4--5---7f64c6e6908de72221a06a06b4a02a6546a4d6d2

With a number index, these would become:

- https://www.nouns.camp/candidates/65
- https://www.nouns.camp/candidates/60

This can later be improved directly in the smart contract, but a subgraph fix will go a long way today.