### PR TITLE
bug fixes: update proposalBySigs flow

### DIFF
--- a/packages/nouns-webapp/src/pages/EditCandidate/index.tsx
+++ b/packages/nouns-webapp/src/pages/EditCandidate/index.tsx
@@ -245,7 +245,7 @@ const EditCandidatePage: React.FC<EditCandidateProps> = props => {
       proposalTransactions.map(({ calldata }) => calldata), // Calldatas
       `# ${titleValue}\n\n${bodyValue}`, // Description
       candidate.data?.slug, // Slug
-      0, // proposalIdToUpdate
+      candidate.data?.proposalIdToUpdate ? candidate.data?.proposalIdToUpdate : 0, // if candidate is an update to a proposal, use the proposalIdToUpdate number
       commitMessage,
       { value: hasVotes ? 0 : updateCandidateCost ?? 0 }, // Fee for non-nouners
     );


### PR DESCRIPTION
1. there was a bug in the Edit Candidate form that wasn't passing `proposalIdToUpdate` when it should. resolved. 
2. Edit Proposal form had a bug that resulted in the page not loading the proposal content properly when reloaded. resolved. 
3. Edit Proposal form validation was being bypassed if the proposal content wasn't properly loaded on reload (see #2). resolved.
4. when updating a proposalBySigs without editing the title, there was an error because the slug of the candidate being created conflicted with the original candidate. resolved. 