### PR TITLE
subgraph: add delegator to delegationEvents

### DIFF
--- a/packages/nouns-subgraph/schema.graphql
+++ b/packages/nouns-subgraph/schema.graphql
@@ -5,6 +5,9 @@ type DelegationEvent @entity {
   "The Noun being delegated"
   noun: Noun!
 
+  "Current delegator address"
+  delegator: Account!
+
   "Previous delegate address"
   previousDelegate: Delegate!
 

--- a/packages/nouns-subgraph/src/nouns-erc-721.ts
+++ b/packages/nouns-subgraph/src/nouns-erc-721.ts
@@ -71,6 +71,7 @@ export function handleDelegateChanged(event: DelegateChanged): void {
     delegateChangedEvent.previousDelegate = previousDelegate.id
       ? previousDelegate.id
       : tokenHolder.id;
+    delegateChangedEvent.delegator = tokenHolder.id.toString();
     delegateChangedEvent.newDelegate = newDelegate.id ? newDelegate.id : tokenHolder.id;
     delegateChangedEvent.save();
   }
@@ -172,6 +173,7 @@ export function handleTransfer(event: Transfer): void {
   delegateChangedEvent.newDelegate = toHolder.delegate
     ? toHolder.delegate!.toString()
     : toHolder.id.toString();
+  delegateChangedEvent.delegator = fromHolder.id.toString();
   delegateChangedEvent.save();
 
   let toHolderDelegate = getOrCreateDelegate(toHolder.delegate ? toHolder.delegate! : toHolder.id);


### PR DESCRIPTION
Trying to build a timeline of delegation events for camp where you can see which account delegated a certain noun, and previous and new delegate values. Today, there's no way to know which account held the noun during delegation, so this PR adds the field `delegator` (present in the original event) to the subgraph.

Using the `delegationEvent {noun.owner}` wouldn't work in this case, since the noun might've been transferred between accounts, and that field only references the latest holder's address.

