### PR TITLE
add $first variable to candies query

### DIFF
--- a/packages/nouns-webapp/src/wrappers/subgraph.ts
+++ b/packages/nouns-webapp/src/wrappers/subgraph.ts
@@ -143,7 +143,7 @@ export const updatableProposalsQuery = (first = 1_000, currentBlock?: number) =>
 
 export const candidateProposalsQuery = (first = 1_000) => gql`
   {
-    proposalCandidates {
+    proposalCandidates(first: ${first}) {
       id
     slug
     proposer


### PR DESCRIPTION
Fixes issue with missing candidates from nouns.wtf due to the default subgraph query limit (100)

With this change, both the 'esports' and 'beyond screens', having been reported missing, will start showing up:
<img width="1058" alt="Screenshot 2023-12-15 at 09 51 06" src="https://github.com/nounsDAO/nouns-monorepo/assets/314617/f52e926f-b46b-4bb6-aa84-c5b70dafc83e">