### PR TITLE
Set a safer default value of 0.01 ether for auctionReservePrice

### DIFF
--- a/packages/nouns-contracts/tasks/deploy-and-configure-short-times-dao-v3.ts
+++ b/packages/nouns-contracts/tasks/deploy-and-configure-short-times-dao-v3.ts
@@ -1,3 +1,4 @@
+import { parseUnits } from 'ethers/lib/utils';
 import { task, types } from 'hardhat/config';
 import { printContractsTable } from './utils';
 
@@ -19,7 +20,7 @@ task(
   .addOptionalParam(
     'auctionReservePrice',
     'The auction reserve price (wei)',
-    1 /* 1 wei */,
+    parseUnits('0.01', 'ether').toNumber() /* 0.01 ether */,
     types.int,
   )
   .addOptionalParam(

--- a/packages/nouns-contracts/tasks/deploy-and-configure-short-times-daov1.ts
+++ b/packages/nouns-contracts/tasks/deploy-and-configure-short-times-daov1.ts
@@ -1,3 +1,4 @@
+import { parseUnits } from 'ethers/lib/utils';
 import { task, types } from 'hardhat/config';
 import { printContractsTable } from './utils';
 
@@ -19,7 +20,7 @@ task(
   .addOptionalParam(
     'auctionReservePrice',
     'The auction reserve price (wei)',
-    1 /* 1 wei */,
+    parseUnits('0.01', 'ether').toNumber() /* 0.01 ether */,
     types.int,
   )
   .addOptionalParam(

--- a/packages/nouns-contracts/tasks/deploy-and-configure-short-times.ts
+++ b/packages/nouns-contracts/tasks/deploy-and-configure-short-times.ts
@@ -1,3 +1,4 @@
+import { parseUnits } from 'ethers/lib/utils';
 import { task, types } from 'hardhat/config';
 import { printContractsTable } from './utils';
 
@@ -19,7 +20,7 @@ task(
   .addOptionalParam(
     'auctionReservePrice',
     'The auction reserve price (wei)',
-    1 /* 1 wei */,
+    parseUnits('0.01', 'ether').toNumber() /* 0.01 ether */,
     types.int,
   )
   .addOptionalParam(

--- a/packages/nouns-contracts/tasks/deploy-local-dao-v3.ts
+++ b/packages/nouns-contracts/tasks/deploy-local-dao-v3.ts
@@ -40,11 +40,16 @@ interface Contract {
 task('deploy-local-dao-v3', 'Deploy contracts to hardhat')
   .addOptionalParam('noundersdao', 'The nounders DAO contract address')
   .addOptionalParam('auctionTimeBuffer', 'The auction time buffer (seconds)', 30, types.int) // Default: 30 seconds
-  .addOptionalParam('auctionReservePrice', 'The auction reserve price (wei)', 1, types.int) // Default: 1 wei
+  .addOptionalParam(
+    'auctionReservePrice',
+    'The auction reserve price (wei)',
+    parseUnits('0.01', 'ether').toNumber(), // Default: 0.01 ether
+    types.int,
+  )
   .addOptionalParam(
     'auctionMinIncrementBidPercentage',
-    'The auction min increment bid percentage (out of 100)', // Default: 5%
-    5,
+    'The auction min increment bid percentage (out of 100)',
+    5, // Default: 5%
     types.int,
   )
   .addOptionalParam('auctionDuration', 'The auction duration (seconds)', 60 * 2, types.int) // Default: 2 minutes

--- a/packages/nouns-contracts/tasks/deploy-local.ts
+++ b/packages/nouns-contracts/tasks/deploy-local.ts
@@ -21,11 +21,16 @@ interface Contract {
 task('deploy-local', 'Deploy contracts to hardhat')
   .addOptionalParam('noundersdao', 'The nounders DAO contract address')
   .addOptionalParam('auctionTimeBuffer', 'The auction time buffer (seconds)', 30, types.int) // Default: 30 seconds
-  .addOptionalParam('auctionReservePrice', 'The auction reserve price (wei)', 1, types.int) // Default: 1 wei
+  .addOptionalParam(
+    'auctionReservePrice',
+    'The auction reserve price (wei)',
+    parseUnits('0.01', 'ether').toNumber(), // Default: 0.01 ether
+    types.int,
+  )
   .addOptionalParam(
     'auctionMinIncrementBidPercentage',
-    'The auction min increment bid percentage (out of 100)', // Default: 5%
-    5,
+    'The auction min increment bid percentage (out of 100)',
+    5, // Default: 5%
     types.int,
   )
   .addOptionalParam('auctionDuration', 'The auction duration (seconds)', 60 * 2, types.int) // Default: 2 minutes

--- a/packages/nouns-contracts/tasks/deploy-short-times-dao-v3.ts
+++ b/packages/nouns-contracts/tasks/deploy-short-times-dao-v3.ts
@@ -41,7 +41,7 @@ task('deploy-short-times-dao-v3', 'Deploy all Nouns contracts with short gov tim
   .addOptionalParam(
     'auctionReservePrice',
     'The auction reserve price (wei)',
-    1 /* 1 wei */,
+    parseUnits('0.01', 'ether').toNumber() /* 0.01 ether */,
     types.int,
   )
   .addOptionalParam(

--- a/packages/nouns-contracts/tasks/deploy-short-times-daov1.ts
+++ b/packages/nouns-contracts/tasks/deploy-short-times-daov1.ts
@@ -1,6 +1,6 @@
 import { default as NounsAuctionHouseABI } from '../abi/contracts/NounsAuctionHouse.sol/NounsAuctionHouse.json';
 import { ChainId, ContractDeployment, ContractName, DeployedContract } from './types';
-import { Interface } from 'ethers/lib/utils';
+import { Interface, parseUnits } from 'ethers/lib/utils';
 import { task, types } from 'hardhat/config';
 import { constants } from 'ethers';
 import promptjs from 'prompt';
@@ -36,7 +36,7 @@ task('deploy-short-times-daov1', 'Deploy all Nouns contracts with short gov time
   .addOptionalParam(
     'auctionReservePrice',
     'The auction reserve price (wei)',
-    1 /* 1 wei */,
+    parseUnits('0.01', 'ether').toNumber() /* 0.01 ether */,
     types.int,
   )
   .addOptionalParam(

--- a/packages/nouns-contracts/tasks/deploy-short-times.ts
+++ b/packages/nouns-contracts/tasks/deploy-short-times.ts
@@ -39,7 +39,7 @@ task('deploy-short-times', 'Deploy all Nouns contracts with short gov times for 
   .addOptionalParam(
     'auctionReservePrice',
     'The auction reserve price (wei)',
-    1 /* 1 wei */,
+    parseUnits('0.01', 'ether').toNumber() /* 0.01 ether */,
     types.int,
   )
   .addOptionalParam(

--- a/packages/nouns-contracts/tasks/deploy.ts
+++ b/packages/nouns-contracts/tasks/deploy.ts
@@ -1,6 +1,6 @@
 import { default as NounsAuctionHouseABI } from '../abi/contracts/NounsAuctionHouse.sol/NounsAuctionHouse.json';
 import { ChainId, ContractDeployment, ContractName, DeployedContract } from './types';
-import { Interface } from 'ethers/lib/utils';
+import { Interface, parseUnits } from 'ethers/lib/utils';
 import { task, types } from 'hardhat/config';
 import { constants } from 'ethers';
 import promptjs from 'prompt';
@@ -36,7 +36,7 @@ task('deploy', 'Deploys NFTDescriptor, NounsDescriptor, NounsSeeder, and NounsTo
   .addOptionalParam(
     'auctionReservePrice',
     'The auction reserve price (wei)',
-    1 /* 1 wei */,
+    parseUnits('0.01', 'ether').toNumber() /* 0.01 ether */,
     types.int,
   )
   .addOptionalParam(


### PR DESCRIPTION
The default value for "auctionReservePrice" in the deployment scripts is currently set at 1 wei which is essentially free. This PR changes the default value to a safer value of 0.01 ether, which makes it less attractive to attackers who will take advantage of less popular auctions. This new reserve price is also made to be consistent with the minimum bid value specified in the webapp: https://github.com/nounsDAO/nouns-monorepo/blob/61d2b50ce82bb060cf4281a55adddf47c5085881/packages/nouns-webapp/src/components/Bid/index.tsx#L35

This issue was recently identified by the members of [nounsBR](https://nounsbr.wtf/). It went unnoticed for quite sometime and the attacker was able to obtain roughly 10% of the token supply and made an attempt at [draining the treasury](https://nounsbr.wtf/vote/10). @sktbrd and members of [Gnars](https://www.gnars.wtf/) worked to mitigate the issue quickly. We think the changes in this PR will reduce the risk of a similar attacks on newly created DAOs.