### PR TITLE
fix: set optimal default value for auctionReservePrice

### DIFF
--- a/packages/nouns-contracts/tasks/deploy-and-configure-short-times-dao-v3.ts
+++ b/packages/nouns-contracts/tasks/deploy-and-configure-short-times-dao-v3.ts
@@ -1,4 +1,5 @@
 import { task, types } from 'hardhat/config';
+import { parseEther } from 'ethers/lib/utils';
 import { printContractsTable } from './utils';
 
 task(
@@ -19,7 +20,7 @@ task(
   .addOptionalParam(
     'auctionReservePrice',
     'The auction reserve price (wei)',
-    1 /* 1 wei */,
+    Number(parseEther('68')) /* 68 Ether */,
     types.int,
   )
   .addOptionalParam(

--- a/packages/nouns-contracts/tasks/deploy-and-configure-short-times-daov1.ts
+++ b/packages/nouns-contracts/tasks/deploy-and-configure-short-times-daov1.ts
@@ -1,4 +1,5 @@
 import { task, types } from 'hardhat/config';
+import { parseEther } from 'ethers/lib/utils';
 import { printContractsTable } from './utils';
 
 task(
@@ -19,7 +20,7 @@ task(
   .addOptionalParam(
     'auctionReservePrice',
     'The auction reserve price (wei)',
-    1 /* 1 wei */,
+    Number(parseEther('68')) /* 68 Ether */,
     types.int,
   )
   .addOptionalParam(

--- a/packages/nouns-contracts/tasks/deploy-and-configure-short-times.ts
+++ b/packages/nouns-contracts/tasks/deploy-and-configure-short-times.ts
@@ -1,4 +1,5 @@
 import { task, types } from 'hardhat/config';
+import { parseEther } from 'ethers/lib/utils';
 import { printContractsTable } from './utils';
 
 task(
@@ -19,7 +20,7 @@ task(
   .addOptionalParam(
     'auctionReservePrice',
     'The auction reserve price (wei)',
-    1 /* 1 wei */,
+    Number(parseEther('68')) /* 68 Ether */,
     types.int,
   )
   .addOptionalParam(

--- a/packages/nouns-contracts/tasks/deploy-local-dao-v3.ts
+++ b/packages/nouns-contracts/tasks/deploy-local-dao-v3.ts
@@ -2,7 +2,7 @@ import { default as NounsAuctionHouseABI } from '../abi/contracts/NounsAuctionHo
 import { default as NounsDaoDataABI } from '../abi/contracts/governance/data/NounsDAOData.sol/NounsDAOData.json';
 import { default as NounsDAOExecutorV2ABI } from '../abi/contracts/governance/NounsDAOExecutorV2.sol/NounsDAOExecutorV2.json';
 import { task, types } from 'hardhat/config';
-import { Interface, parseUnits } from 'ethers/lib/utils';
+import { Interface, parseUnits, parseEther } from 'ethers/lib/utils';
 import { Contract as EthersContract } from 'ethers';
 import { ContractName } from './types';
 
@@ -40,11 +40,16 @@ interface Contract {
 task('deploy-local-dao-v3', 'Deploy contracts to hardhat')
   .addOptionalParam('noundersdao', 'The nounders DAO contract address')
   .addOptionalParam('auctionTimeBuffer', 'The auction time buffer (seconds)', 30, types.int) // Default: 30 seconds
-  .addOptionalParam('auctionReservePrice', 'The auction reserve price (wei)', 1, types.int) // Default: 1 wei
+  .addOptionalParam(
+    'auctionReservePrice',
+    'The auction reserve price (wei)',
+    Number(parseEther('68')), // Default: 68 Ether
+    types.int
+    )
   .addOptionalParam(
     'auctionMinIncrementBidPercentage',
-    'The auction min increment bid percentage (out of 100)', // Default: 5%
-    5,
+    'The auction min increment bid percentage (out of 100)',
+    5, // Default: 5%
     types.int,
   )
   .addOptionalParam('auctionDuration', 'The auction duration (seconds)', 60 * 2, types.int) // Default: 2 minutes

--- a/packages/nouns-contracts/tasks/deploy-local.ts
+++ b/packages/nouns-contracts/tasks/deploy-local.ts
@@ -1,6 +1,6 @@
 import { default as NounsAuctionHouseABI } from '../abi/contracts/NounsAuctionHouse.sol/NounsAuctionHouse.json';
 import { task, types } from 'hardhat/config';
-import { Interface, parseUnits } from 'ethers/lib/utils';
+import { Interface, parseUnits, parseEther } from 'ethers/lib/utils';
 import { Contract as EthersContract } from 'ethers';
 import { ContractName } from './types';
 
@@ -21,11 +21,16 @@ interface Contract {
 task('deploy-local', 'Deploy contracts to hardhat')
   .addOptionalParam('noundersdao', 'The nounders DAO contract address')
   .addOptionalParam('auctionTimeBuffer', 'The auction time buffer (seconds)', 30, types.int) // Default: 30 seconds
-  .addOptionalParam('auctionReservePrice', 'The auction reserve price (wei)', 1, types.int) // Default: 1 wei
+  .addOptionalParam(
+    'auctionReservePrice',
+    'The auction reserve price (wei)',
+    Number(parseEther('68')), // Default: 68 Ether
+    types.int
+    )
   .addOptionalParam(
     'auctionMinIncrementBidPercentage',
-    'The auction min increment bid percentage (out of 100)', // Default: 5%
-    5,
+    'The auction min increment bid percentage (out of 100)',
+    5, // Default: 5%
     types.int,
   )
   .addOptionalParam('auctionDuration', 'The auction duration (seconds)', 60 * 2, types.int) // Default: 2 minutes

--- a/packages/nouns-contracts/tasks/deploy-short-times-dao-v3.ts
+++ b/packages/nouns-contracts/tasks/deploy-short-times-dao-v3.ts
@@ -2,7 +2,7 @@ import { default as NounsAuctionHouseABI } from '../abi/contracts/NounsAuctionHo
 import { default as NounsDAOExecutorV2ABI } from '../abi/contracts/governance/NounsDAOExecutorV2.sol/NounsDAOExecutorV2.json';
 import { default as NounsDaoDataABI } from '../abi/contracts/governance/data/NounsDAOData.sol/NounsDAOData.json';
 import { ChainId, ContractDeployment, ContractNamesDAOV3, DeployedContract } from './types';
-import { Interface, parseUnits } from 'ethers/lib/utils';
+import { Interface, parseUnits, parseEther } from 'ethers/lib/utils';
 import { task, types } from 'hardhat/config';
 import { constants } from 'ethers';
 import promptjs from 'prompt';
@@ -41,7 +41,7 @@ task('deploy-short-times-dao-v3', 'Deploy all Nouns contracts with short gov tim
   .addOptionalParam(
     'auctionReservePrice',
     'The auction reserve price (wei)',
-    1 /* 1 wei */,
+    Number(parseEther('68')) /* 68 ether */,
     types.int,
   )
   .addOptionalParam(

--- a/packages/nouns-contracts/tasks/deploy-short-times-daov1.ts
+++ b/packages/nouns-contracts/tasks/deploy-short-times-daov1.ts
@@ -1,6 +1,6 @@
 import { default as NounsAuctionHouseABI } from '../abi/contracts/NounsAuctionHouse.sol/NounsAuctionHouse.json';
 import { ChainId, ContractDeployment, ContractName, DeployedContract } from './types';
-import { Interface } from 'ethers/lib/utils';
+import { Interface, parseEther} from 'ethers/lib/utils';
 import { task, types } from 'hardhat/config';
 import { constants } from 'ethers';
 import promptjs from 'prompt';
@@ -36,7 +36,7 @@ task('deploy-short-times-daov1', 'Deploy all Nouns contracts with short gov time
   .addOptionalParam(
     'auctionReservePrice',
     'The auction reserve price (wei)',
-    1 /* 1 wei */,
+    Number(parseEther('68')) /* 68 ether */,
     types.int,
   )
   .addOptionalParam(

--- a/packages/nouns-contracts/tasks/deploy-short-times.ts
+++ b/packages/nouns-contracts/tasks/deploy-short-times.ts
@@ -1,6 +1,6 @@
 import { default as NounsAuctionHouseABI } from '../abi/contracts/NounsAuctionHouse.sol/NounsAuctionHouse.json';
 import { ChainId, ContractDeployment, ContractNamesDAOV2, DeployedContract } from './types';
-import { Interface, parseUnits } from 'ethers/lib/utils';
+import { Interface, parseUnits, parseEther} from 'ethers/lib/utils';
 import { task, types } from 'hardhat/config';
 import { constants } from 'ethers';
 import promptjs from 'prompt';
@@ -39,7 +39,7 @@ task('deploy-short-times', 'Deploy all Nouns contracts with short gov times for 
   .addOptionalParam(
     'auctionReservePrice',
     'The auction reserve price (wei)',
-    1 /* 1 wei */,
+    Number(parseEther('68')) /* 68 ether */,
     types.int,
   )
   .addOptionalParam(

--- a/packages/nouns-contracts/tasks/deploy.ts
+++ b/packages/nouns-contracts/tasks/deploy.ts
@@ -1,6 +1,6 @@
 import { default as NounsAuctionHouseABI } from '../abi/contracts/NounsAuctionHouse.sol/NounsAuctionHouse.json';
 import { ChainId, ContractDeployment, ContractName, DeployedContract } from './types';
-import { Interface } from 'ethers/lib/utils';
+import { Interface, parseEther } from 'ethers/lib/utils';
 import { task, types } from 'hardhat/config';
 import { constants } from 'ethers';
 import promptjs from 'prompt';
@@ -36,7 +36,7 @@ task('deploy', 'Deploys NFTDescriptor, NounsDescriptor, NounsSeeder, and NounsTo
   .addOptionalParam(
     'auctionReservePrice',
     'The auction reserve price (wei)',
-    1 /* 1 wei */,
+    Number(parseEther('68')) /* 68 ether */,
     types.int,
   )
   .addOptionalParam(


### PR DESCRIPTION
In the current deployment scripts for the nounish auction contracts the value for the state variable “auctionReservePrice” is set to a default value of 1 wei. This value leaves a lot of room for human error and has been recently exploited to settle multiple auctions with small bids of 1 wei. This vulnerability has not only caused loss of revenue to some DAOs that relied on affected deployment scripts, but it has also potentially left them vulnerable to sybil attacks launched with the governance tokens that have thus been accumulated virtually for free.

### TL;DR: 
When we set a default value that will be customized by the user, there are only two outcomes:
1. Either the user will adjust it up because our default value is lower than the desired value
2. Or they'll adjust it down because it was higher than the desired value
Any default value that requires devs to adjust the value up will introduce security vulnerabilities given that they can forget to make the adjustment or they can adjust it up to a value that is still incorrect given that they're starting with a low reference point, and as a catastrophic result the auction will settle at undesired prices. Asking devs to input the value even with a madatory prompt is equivalent to adjusting up from 0. It is thus a fragile fix. 
**Given that reserve prices build up a treasury there is no such thing as a reserve price that is too high.** Therefore the only robust and systematic solution is to set a high default value for the reserve price and require devs to adjust it down if need be as this gives them a desirable and secure reference point as well as a verified channel (the governance process) with which they can evaluate whether or not they set the correct value. And if they forget to make the initial adjustment to the high default value attackers cannot take advantage of this oversight given the high cost for settling the misconfigured auction. This implements a security model of defense through deterrence. An even more desirable aspect of this approach is that setting a correct value for the reserve price will be non-optional given a high default value. 

This second approach is therefore the only secure and guaranteed way to make updating the reserve price a non-optional configuration implemented with minimal code change.

In addition to being the most secure solution, requiring devs to adjust down the default reserve price creates very strategic opportunities for quickly bootstrapping treasuries as it will make every first auction of a new Nouns extension behave as a Dutch auction. An adjusting down outcome has therefore the major bonus of also making the Nouns protocol more successful in its stated mission of building an infrastructure that enables communities to bootstrap treasury.

Let us begin the festivities.

### MOTIVATION

A pull request proposing [to raise this default value to 0.01 Ether was submitted earlier.](https://github.com/nounsDAO/nouns-monorepo/pull/829)
This is `an adjust up outcome` that introduces potential vulnerabilities. After a thorough review of that pull request I feel compelled to submit a new pull request that takes a strategic departure from the solution proposed in that previous pull request to provide a more robust solution to the set of problems tied to this vulnerability, as well as a cleaner syntax that adds greater clarity and readability to the statement setting the value for "auctionReservePrice"

This approach implements `an adjust down strategy` that is systematically secure.
Here’s the rationale for this best default value proposed in the following pull request:

👉 Given that there is a large dispersion in the value of “auctionReservePrice” that future DAOs will implement, the probability that such DAOs end up failing to properly initialize this state variable to a value that is optimal for their community is very high given a default of 0.01 Ether, or given any arbitrary values, even one provided by the developers themselves before deployment. Therefore this commit defines a universal best default value that completely eliminates such a failure while leaving no room whatsoever for human error.

👉 And given that the underlying cause of the vulnerability we are presently patching is that a default value for "auctionReservePrice" was set using a naïve approach, this commit therefore provides a new default value characterized by a higher degree of bayesian sophistication because it is derived from a set of equations powered by game theory to inform [optimal reserve price selection in an adversarial bidding environment](https://www.sciencedirect.com/science/article/abs/pii/S0899825603000058).

As a result, this commit sets the new default value for the state variable “auctionReservePrice” at 68 Ether.

👉 Even if a default value of 68ETH is not optimal for a given DAO it turns out that it does protect the community from a failure to set the best value for "auctionReservePrice" since it establishes a high reserve price that ensures that the first auction cannot be won unless the correct adjusted reserve price has been set. Thus the proposed best default value serves as a forcing function that ensures that every DAO implementing this code must set the default value for "auctionReservePrice" to one that is optimal for their particular community.

👉 Most notably, this default value will allow the first auction of all future DAOs to work like a dutch auction: an auction starting with a relatively high reserve price that is adjusted down if the community so chooses. This will help Nouns fulfil its mission of providing a powerful infrastructure that helps communities bootstrap their treasuries. It must be noted that the opportunity to maximize the revenue of all future DOAs **with one simple adjustable parameter, strong security guarantees, and zero side effects is just too great to pass up.**

Therefore, I submit this PR for review and eagerly anticipate feedback from the community.

### ACKNOWLEDGEMENTS

I wish to end this PR on a high note by highlighting the many conscientious and industrious individuals in ecosystem who submitted ideas, feedback, and code that has been integrated in this fix. So here’s a credit list to applaud each contributor’s efforts in noticing, discussing, and drafting a patch for this vulnerability, all with admirable expediency:

- https://github.com/sktbrd
- https://github.com/0xMillz
- https://github.com/bagelface

Long live the nounish buidlers ✨