### PR TITLE
deploy script: use fee data to avoid gas errors

### DIFF
--- a/packages/nouns-contracts/tasks/deploy-short-times-dao-v3.ts
+++ b/packages/nouns-contracts/tasks/deploy-short-times-dao-v3.ts
@@ -287,9 +287,22 @@ task('deploy-short-times-dao-v3', 'Deploy all Nouns contracts with short gov tim
     };
 
     for (const [name, contract] of Object.entries(contracts)) {
-      let gasPrice = await ethers.provider.getGasPrice();
+      let gasOptions;
+      let feeData = await ethers.provider.getFeeData();
+      if (args.autoDeploy) {
+        gasOptions = {
+          maxFeePerGas: feeData.maxFeePerGas,
+          maxPriorityFeePerGas: feeData.maxPriorityFeePerGas,
+        };
+      } else {
+        gasOptions = {
+          gasPrice: feeData.gasPrice!,
+        };
+      }
       if (!args.autoDeploy) {
-        const gasInGwei = Math.round(Number(ethers.utils.formatUnits(gasPrice, 'gwei')));
+        const gasInGwei = Math.round(
+          Number(ethers.utils.formatUnits(gasOptions.gasPrice!, 'gwei')),
+        );
 
         promptjs.start();
 
@@ -305,7 +318,7 @@ task('deploy-short-times-dao-v3', 'Deploy all Nouns contracts with short gov tim
             },
           },
         ]);
-        gasPrice = ethers.utils.parseUnits(result.gasPrice.toString(), 'gwei');
+        gasOptions.gasPrice = ethers.utils.parseUnits(result.gasPrice.toString(), 'gwei');
       }
 
       let nameForFactory: string;
@@ -328,21 +341,20 @@ task('deploy-short-times-dao-v3', 'Deploy all Nouns contracts with short gov tim
       const deploymentGas = await factory.signer.estimateGas(
         factory.getDeployTransaction(
           ...(contract.args?.map(a => (typeof a === 'function' ? a() : a)) ?? []),
-          {
-            gasPrice,
-          },
+          gasOptions,
         ),
-      );
-      const deploymentCost = deploymentGas.mul(gasPrice);
-
-      console.log(
-        `Estimated cost to deploy ${name}: ${ethers.utils.formatUnits(
-          deploymentCost,
-          'ether',
-        )} ETH`,
       );
 
       if (!args.autoDeploy) {
+        const deploymentCost = deploymentGas.mul(gasOptions.gasPrice!);
+
+        console.log(
+          `Estimated cost to deploy ${name}: ${ethers.utils.formatUnits(
+            deploymentCost,
+            'ether',
+          )} ETH`,
+        );
+
         const result = await promptjs.get([
           {
             properties: {
@@ -367,9 +379,7 @@ task('deploy-short-times-dao-v3', 'Deploy all Nouns contracts with short gov tim
 
       const deployedContract = await factory.deploy(
         ...(contract.args?.map(a => (typeof a === 'function' ? a() : a)) ?? []),
-        {
-          gasPrice,
-        },
+        gasOptions,
       );
 
       if (contract.waitForConfirmation) {


### PR DESCRIPTION
did this fix after I got the error: `max fee per gas less than block base fee` when trying to deploy