### PR TITLE
Fix for rewards contract following audit

### DIFF
--- a/packages/nouns-contracts/contracts/client-incentives/Rewards.sol
+++ b/packages/nouns-contracts/contracts/client-incentives/Rewards.sol
@@ -330,6 +330,7 @@ contract Rewards is
             votingClientIds
         );
         require(proposals.length > 0, 'at least one eligible proposal');
+        t.numEligibleProposals = proposals.length;
         $.nextProposalIdToReward = lastProposalId + 1;
 
         t.lastProposal = proposals[proposals.length - 1];
@@ -360,8 +361,6 @@ contract Rewards is
             uint256 votesInProposal = proposals[i].forVotes + proposals[i].againstVotes + proposals[i].abstainVotes;
             t.numEligibleVotes += votesInProposal;
         }
-
-        t.numEligibleProposals = proposals.length;
 
         //// Check that distribution is allowed:
         //// 1. One of the two conditions must be true:

--- a/packages/nouns-contracts/contracts/client-incentives/Rewards.sol
+++ b/packages/nouns-contracts/contracts/client-incentives/Rewards.sol
@@ -294,14 +294,19 @@ contract Rewards is
 
     /**
      * @notice Distribute rewards for proposal creation and voting from the last update until `lastProposalId`.
-     * A proposal is eligible for rewards if for-votes/total-votes >= params.proposalEligibilityQuorumBps.
-     * Rewards are calculated by the auctions revenue during the period between the creation time of last proposal in
-     * the previous update until the current last proposal with id `lastProposalId`.
+     * A proposal is eligible for rewards if it wasn't canceled and for-votes/total-votes >= params.proposalEligibilityQuorumBps.
+     * Rewards are calculated by the auctions revenue during the period between the creation time of last processed
+     * eligible proposal in until the current last eligible proposal with id <= `lastProposalId`.
+     * One of two conditions must be true in order for rewards to be distributed:
+     * 1. There are at least `numProposalsEnoughForReward` proposals in this update
+     * 2. At least `minimumRewardPeriod` time has passed since the last update until the creation time of the last
+     *     eligible proposal in this update.
      * Gas spent is refunded in `ethToken`.
      * @param lastProposalId id of the last proposal to include in the rewards distribution. all proposals up to and
      * including this id must have ended voting.
      * @param votingClientIds array of sorted client ids that were used to vote on the eligible proposals in
-     * this rewards distribution. reverts if contains duplicates. reverts if not sorted. reverts if a clientId had zero votes.
+     * this rewards distribution. Reverts if it contains duplicates. Reverts if it's not sorted. Reverts if a clientId
+     * had zero votes on all eligible proposals from this update.
      * You may use `getVotingClientIds` as a convenience function to get the correct `votingClientIds`.
      */
     function updateRewardsForProposalWritingAndVoting(

--- a/packages/nouns-contracts/contracts/governance/NounsDAOLogicV4.sol
+++ b/packages/nouns-contracts/contracts/governance/NounsDAOLogicV4.sol
@@ -523,6 +523,9 @@ contract NounsDAOLogicV4 is NounsDAOStorage, NounsDAOEventsV3 {
      * @notice Get a range of proposals, in the format of a samller struct tailored to client incentives rewards.
      * @param firstProposalId the id of the first proposal to get the data for
      * @param lastProposalId the id of the last proposal to get the data for
+     * @param proposalEligibilityQuorumBps filters proposals with for-votes/total-supply higher than this quorum
+     * @param excludeCanceled if true, excludes canceled proposals
+     * @param requireVotingEnded if true, reverts if one of the proposals hasn't finished voting yet
      * @param votingClientIds the ids of the clients that facilitated votes on the proposals
      * @return An array of `ProposalForRewards` structs with the proposal data
      */
@@ -531,6 +534,7 @@ contract NounsDAOLogicV4 is NounsDAOStorage, NounsDAOEventsV3 {
         uint256 lastProposalId,
         uint16 proposalEligibilityQuorumBps,
         bool excludeCanceled,
+        bool requireVotingEnded,
         uint32[] calldata votingClientIds
     ) external view returns (ProposalForRewards[] memory) {
         return
@@ -539,6 +543,7 @@ contract NounsDAOLogicV4 is NounsDAOStorage, NounsDAOEventsV3 {
                 lastProposalId,
                 proposalEligibilityQuorumBps,
                 excludeCanceled,
+                requireVotingEnded,
                 votingClientIds
             );
     }

--- a/packages/nouns-contracts/contracts/governance/NounsDAOLogicV4.sol
+++ b/packages/nouns-contracts/contracts/governance/NounsDAOLogicV4.sol
@@ -529,9 +529,18 @@ contract NounsDAOLogicV4 is NounsDAOStorage, NounsDAOEventsV3 {
     function proposalDataForRewards(
         uint256 firstProposalId,
         uint256 lastProposalId,
+        uint16 proposalEligibilityQuorumBps,
+        bool excludeCanceled,
         uint32[] calldata votingClientIds
     ) external view returns (ProposalForRewards[] memory) {
-        return ds.proposalDataForRewards(firstProposalId, lastProposalId, votingClientIds);
+        return
+            ds.proposalDataForRewards(
+                firstProposalId,
+                lastProposalId,
+                proposalEligibilityQuorumBps,
+                excludeCanceled,
+                votingClientIds
+            );
     }
 
     /**

--- a/packages/nouns-contracts/contracts/governance/NounsDAOProposals.sol
+++ b/packages/nouns-contracts/contracts/governance/NounsDAOProposals.sol
@@ -734,7 +734,10 @@ library NounsDAOProposals {
             proposal = ds._proposals[pid];
 
             if (excludeCanceled && proposal.canceled) continue;
-            if (proposal.forVotes < (proposal.totalSupply * proposalEligibilityQuorumBps) / 10_000) continue;
+
+            uint256 forVotes = proposal.forVotes;
+            uint256 totalSupply = proposal.totalSupply;
+            if (forVotes < (totalSupply * proposalEligibilityQuorumBps) / 10_000) continue;
 
             NounsDAOTypes.ClientVoteData[] memory c = new NounsDAOTypes.ClientVoteData[](votingClientIds.length);
             for (uint256 j; j < votingClientIds.length; ++j) {
@@ -744,10 +747,10 @@ library NounsDAOProposals {
             data[i++] = NounsDAOTypes.ProposalForRewards({
                 endBlock: proposal.endBlock,
                 objectionPeriodEndBlock: proposal.objectionPeriodEndBlock,
-                forVotes: proposal.forVotes,
+                forVotes: forVotes,
                 againstVotes: proposal.againstVotes,
                 abstainVotes: proposal.abstainVotes,
-                totalSupply: proposal.totalSupply,
+                totalSupply: totalSupply,
                 creationTimestamp: proposal.creationTimestamp,
                 clientId: proposal.clientId,
                 voteData: c

--- a/packages/nouns-contracts/contracts/interfaces/INounsDAOLogic.sol
+++ b/packages/nouns-contracts/contracts/interfaces/INounsDAOLogic.sol
@@ -266,6 +266,7 @@ interface INounsDAOLogic {
         uint256 lastProposalId,
         uint16 proposalEligibilityQuorumBps,
         bool excludeCanceled,
+        bool requireVotingEnded,
         uint32[] calldata votingClientIds
     ) external view returns (NounsDAOTypes.ProposalForRewards[] memory);
 

--- a/packages/nouns-contracts/contracts/interfaces/INounsDAOLogic.sol
+++ b/packages/nouns-contracts/contracts/interfaces/INounsDAOLogic.sol
@@ -264,6 +264,8 @@ interface INounsDAOLogic {
     function proposalDataForRewards(
         uint256 firstProposalId,
         uint256 lastProposalId,
+        uint16 proposalEligibilityQuorumBps,
+        bool excludeCanceled,
         uint32[] calldata votingClientIds
     ) external view returns (NounsDAOTypes.ProposalForRewards[] memory);
 
@@ -443,7 +445,7 @@ interface INounsDAOLogic {
 
     /**
      * @notice Admin function for zeroing out the state variable `voteSnapshotBlockSwitchProposalId`
-     * @dev We want to zero-out this state slot so we can remove this temporary variable from contract code and 
+     * @dev We want to zero-out this state slot so we can remove this temporary variable from contract code and
      * be ready to reuse this slot.
      */
     function _zeroOutVoteSnapshotBlockSwitchProposalId() external;

--- a/packages/nouns-contracts/test/foundry/NounsDAOLogic/Propose.t.sol
+++ b/packages/nouns-contracts/test/foundry/NounsDAOLogic/Propose.t.sol
@@ -90,6 +90,7 @@ contract ProposalDataForRewardsTest is NounsDAOLogicBaseTest {
             lastProposalId: proposalId,
             proposalEligibilityQuorumBps: 0,
             excludeCanceled: false,
+            requireVotingEnded: false,
             votingClientIds: emptyArray
         });
 
@@ -109,10 +110,42 @@ contract ProposalDataForRewardsTest is NounsDAOLogicBaseTest {
             lastProposalId: proposalId,
             proposalEligibilityQuorumBps: 0,
             excludeCanceled: true,
+            requireVotingEnded: false,
             votingClientIds: emptyArray
         });
 
         assertEq(data.length, 0);
+    }
+
+    function test_requireVotingEnded_revertsIfVotingNotEnded() public {
+        uint256 proposalId = propose(proposer, address(1), 0, '', '', 'proposal', 123);
+
+        uint32[] memory emptyArray = new uint32[](0);
+        vm.expectRevert('all proposals must be done with voting');
+        dao.proposalDataForRewards({
+            firstProposalId: proposalId,
+            lastProposalId: proposalId,
+            proposalEligibilityQuorumBps: 0,
+            excludeCanceled: true,
+            requireVotingEnded: true,
+            votingClientIds: emptyArray
+        });
+    }
+
+    function test_requireVotingEnded_doesntRevertIfVotingEnded() public {
+        uint256 proposalId = propose(proposer, address(1), 0, '', '', 'proposal', 123);
+
+        vm.roll(dao.proposals(proposalId).endBlock + 1);
+
+        uint32[] memory emptyArray = new uint32[](0);
+        dao.proposalDataForRewards({
+            firstProposalId: proposalId,
+            lastProposalId: proposalId,
+            proposalEligibilityQuorumBps: 0,
+            excludeCanceled: true,
+            requireVotingEnded: true,
+            votingClientIds: emptyArray
+        });
     }
 
     function test_includesCanceledProposalsIfFlagIsOff() public {
@@ -127,6 +160,7 @@ contract ProposalDataForRewardsTest is NounsDAOLogicBaseTest {
             lastProposalId: proposalId,
             proposalEligibilityQuorumBps: 0,
             excludeCanceled: false,
+            requireVotingEnded: false,
             votingClientIds: emptyArray
         });
 
@@ -142,6 +176,7 @@ contract ProposalDataForRewardsTest is NounsDAOLogicBaseTest {
             lastProposalId: proposalId,
             proposalEligibilityQuorumBps: 2000,
             excludeCanceled: false,
+            requireVotingEnded: false,
             votingClientIds: emptyArray
         });
 
@@ -156,6 +191,7 @@ contract ProposalDataForRewardsTest is NounsDAOLogicBaseTest {
             lastProposalId: proposalId,
             proposalEligibilityQuorumBps: 2000,
             excludeCanceled: false,
+            requireVotingEnded: false,
             votingClientIds: emptyArray
         });
 

--- a/packages/nouns-contracts/test/foundry/NounsDAOLogic/Propose.t.sol
+++ b/packages/nouns-contracts/test/foundry/NounsDAOLogic/Propose.t.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.15;
 
 import 'forge-std/Test.sol';
 import { NounsDAOLogicBaseTest } from './NounsDAOLogicBaseTest.sol';
+import { NounsDAOTypes } from '../../../contracts/governance/NounsDAOInterfaces.sol';
 
 contract ProposeTest is NounsDAOLogicBaseTest {
     address proposer = makeAddr('proposer');
@@ -58,5 +59,106 @@ contract ProposeTest is NounsDAOLogicBaseTest {
         vm.prank(proposer);
 
         dao.propose(targets, values, signatures, calldatas, 'some description');
+    }
+}
+
+contract ProposalDataForRewardsTest is NounsDAOLogicBaseTest {
+    address proposer = makeAddr('proposer');
+    address voter = makeAddr('voter');
+
+    function setUp() public override {
+        super.setUp();
+
+        vm.prank(address(dao.timelock()));
+        dao._setProposalThresholdBPS(1_000);
+
+        for (uint256 i = 0; i < 10; i++) {
+            mintTo(proposer);
+        }
+
+        for (uint256 i = 0; i < 3; i++) {
+            mintTo(voter);
+        }
+    }
+
+    function test_returnsData() public {
+        uint256 proposalId = propose(proposer, address(1), 0, '', '', 'proposal', 123);
+        uint32[] memory emptyArray = new uint32[](0);
+
+        NounsDAOTypes.ProposalForRewards[] memory data = dao.proposalDataForRewards({
+            firstProposalId: proposalId,
+            lastProposalId: proposalId,
+            proposalEligibilityQuorumBps: 0,
+            excludeCanceled: false,
+            votingClientIds: emptyArray
+        });
+
+        assertEq(data[0].clientId, 123);
+        assertEq(data[0].creationTimestamp, block.timestamp);
+    }
+
+    function test_excludesCanceledProposalsIfFlagIsOn() public {
+        uint256 proposalId = propose(proposer, address(1), 0, '', '', 'proposal', 123);
+
+        vm.prank(proposer);
+        dao.cancel(proposalId);
+
+        uint32[] memory emptyArray = new uint32[](0);
+        NounsDAOTypes.ProposalForRewards[] memory data = dao.proposalDataForRewards({
+            firstProposalId: proposalId,
+            lastProposalId: proposalId,
+            proposalEligibilityQuorumBps: 0,
+            excludeCanceled: true,
+            votingClientIds: emptyArray
+        });
+
+        assertEq(data.length, 0);
+    }
+
+    function test_includesCanceledProposalsIfFlagIsOff() public {
+        uint256 proposalId = propose(proposer, address(1), 0, '', '', 'proposal', 123);
+
+        vm.prank(proposer);
+        dao.cancel(proposalId);
+
+        uint32[] memory emptyArray = new uint32[](0);
+        NounsDAOTypes.ProposalForRewards[] memory data = dao.proposalDataForRewards({
+            firstProposalId: proposalId,
+            lastProposalId: proposalId,
+            proposalEligibilityQuorumBps: 0,
+            excludeCanceled: false,
+            votingClientIds: emptyArray
+        });
+
+        assertEq(data.length, 1);
+    }
+
+    function test_filtersProposalsBasedOnQuorum() public {
+        uint256 proposalId = propose(proposer, address(1), 0, '', '', 'proposal', 123);
+
+        uint32[] memory emptyArray = new uint32[](0);
+        NounsDAOTypes.ProposalForRewards[] memory data = dao.proposalDataForRewards({
+            firstProposalId: proposalId,
+            lastProposalId: proposalId,
+            proposalEligibilityQuorumBps: 2000,
+            excludeCanceled: false,
+            votingClientIds: emptyArray
+        });
+
+        assertEq(data.length, 0);
+
+        vm.roll(dao.proposals(proposalId).startBlock + 1);
+        vm.prank(voter);
+        dao.castRefundableVote(proposalId, 1);
+
+        data = dao.proposalDataForRewards({
+            firstProposalId: proposalId,
+            lastProposalId: proposalId,
+            proposalEligibilityQuorumBps: 2000,
+            excludeCanceled: false,
+            votingClientIds: emptyArray
+        });
+
+        assertEq(data.length, 1);
     }
 }

--- a/packages/nouns-contracts/test/foundry/Upgrade/UpgradeMainnetFork.t.sol
+++ b/packages/nouns-contracts/test/foundry/Upgrade/UpgradeMainnetFork.t.sol
@@ -200,7 +200,7 @@ contract DAOUpgradeMainnetForkTest is UpgradeMainnetForkBaseTest {
     }
 
     function getProposalDataForRewards(uint256 proposalId) internal returns (NounsDAOTypes.ProposalForRewards memory) {
-        return NOUNS_DAO_PROXY_MAINNET.proposalDataForRewards(proposalId, proposalId, new uint32[](0))[0];
+        return NOUNS_DAO_PROXY_MAINNET.proposalDataForRewards(proposalId, proposalId, 0, false, new uint32[](0))[0];
     }
 
     function test_clientId_savedOnVotes() public {
@@ -223,6 +223,8 @@ contract DAOUpgradeMainnetForkTest is UpgradeMainnetForkBaseTest {
         NounsDAOTypes.ProposalForRewards[] memory propsData = NOUNS_DAO_PROXY_MAINNET.proposalDataForRewards(
             proposalId,
             proposalId,
+            0,
+            false,
             clientIds
         );
         NounsDAOTypes.ClientVoteData[] memory voteData = propsData[0].voteData;

--- a/packages/nouns-contracts/test/foundry/Upgrade/UpgradeMainnetFork.t.sol
+++ b/packages/nouns-contracts/test/foundry/Upgrade/UpgradeMainnetFork.t.sol
@@ -200,7 +200,8 @@ contract DAOUpgradeMainnetForkTest is UpgradeMainnetForkBaseTest {
     }
 
     function getProposalDataForRewards(uint256 proposalId) internal returns (NounsDAOTypes.ProposalForRewards memory) {
-        return NOUNS_DAO_PROXY_MAINNET.proposalDataForRewards(proposalId, proposalId, 0, false, new uint32[](0))[0];
+        return
+            NOUNS_DAO_PROXY_MAINNET.proposalDataForRewards(proposalId, proposalId, 0, false, false, new uint32[](0))[0];
     }
 
     function test_clientId_savedOnVotes() public {
@@ -224,6 +225,7 @@ contract DAOUpgradeMainnetForkTest is UpgradeMainnetForkBaseTest {
             proposalId,
             proposalId,
             0,
+            false,
             false,
             clientIds
         );

--- a/packages/nouns-contracts/test/foundry/rewards/ProposalRewards.t.sol
+++ b/packages/nouns-contracts/test/foundry/rewards/ProposalRewards.t.sol
@@ -501,7 +501,7 @@ contract ProposalRewardsEligibilityTest is BaseProposalRewardsTest {
     }
 
     function test_eligibleIfAboveQuorum() public {
-        params.proposalEligibilityQuorumBps = 7000;
+        params.proposalEligibilityQuorumBps = 7000; // (12 * 7000 / 10000) = 8
         vm.prank(address(dao.timelock()));
         rewards.setParams(params);
 
@@ -512,7 +512,7 @@ contract ProposalRewardsEligibilityTest is BaseProposalRewardsTest {
     }
 
     function test_canceledProposalsAreIneligible() public {
-        params.proposalEligibilityQuorumBps = 7000;
+        params.proposalEligibilityQuorumBps = 7000; // (12 * 7000 / 10000) = 8
         vm.prank(address(dao.timelock()));
         rewards.setParams(params);
 

--- a/packages/nouns-contracts/test/foundry/rewards/ProposalRewards.t.sol
+++ b/packages/nouns-contracts/test/foundry/rewards/ProposalRewards.t.sol
@@ -320,6 +320,10 @@ contract ProposalRewardsTest is BaseProposalRewardsTest {
     }
 
     function test_cantUseIneligibleProposalToPassTheMinimumPeriod() public {
+        // The state in this test:
+        // Number of eligible proposals < `numProposalsEnoughForReward`
+        // The last proposal is after `minimumRewardPeriod`, but it's not eligible, so it shouldn't
+        // be considered when looking at how much time passed.
         uint256 startTimestamp = block.timestamp;
 
         bidAndSettleAuction({ bidAmount: 5 ether });

--- a/packages/nouns-contracts/test/foundry/rewards/ProposalRewards.t.sol
+++ b/packages/nouns-contracts/test/foundry/rewards/ProposalRewards.t.sol
@@ -786,7 +786,8 @@ contract VotesRewardsTest is BaseProposalRewardsTest {
         mineBlocks(VOTING_PERIOD);
         uint32[] memory votingClientIds = rewards.getVotingClientIds(proposalId2);
 
-        // doesn't revert
+        // doesn't revert. if votingClientIds included clientId1 then it would revert because the first proposal is
+        // ineligible, so clientId1 has zero votes
         rewards.updateRewardsForProposalWritingAndVoting({
             lastProposalId: proposalId2,
             votingClientIds: votingClientIds


### PR DESCRIPTION
This fix changes the way the proposal rewards calculate the auction revenue. Instead of taking the user provided lastProposalId's creation timestamp, we use the last *eligible* proposal that is <= lastProposalId. The reason is we don't want users creating bogus proposals just for controlling the end timestamp.

In addition, we also consider canceled proposals to be ineligible. This is to prevent a user with quorum votes to create proposals, vote, and cancel, just to get rewards.