### PR TITLE
Added bid txn hash to subgraph + fixed webapp historical auction bid links

### DIFF
--- a/packages/nouns-subgraph/README.md
+++ b/packages/nouns-subgraph/README.md
@@ -46,6 +46,16 @@ yarn deploy:[network] # Supports rinkeby and mainnet
 yarn deploy [organization]/[subgraph-name]
 ```
 
+### Compile and deploy to The Graph studio for The Graph's decentralized network
+
+```sh
+# Auth (only the first time)
+yarn graph auth [deploy-key] --product=subgraph-studio
+
+# Deploy
+yarn deploy-studio:[network] # mainnet|sepolia
+```
+
 ## Running a local deployment
 
 Make sure you have Docker installed.

--- a/packages/nouns-subgraph/config/sepolia.json
+++ b/packages/nouns-subgraph/config/sepolia.json
@@ -1,19 +1,19 @@
 {
   "network": "sepolia",
   "nounsToken": {
-    "address": "0x03439d47983d48C0402D2e88C5F8368d6B6BaC77",
-    "startBlock": 5301488
+    "address": "0x4C4674bb72a096855496a7204962297bd7e12b85",
+    "startBlock": 3594846
   },
   "nounsAuctionHouse": {
-    "address": "0x09BD4d1066a2f4AD4445f60De356bfc9494b5C0d",
-    "startBlock": 5301519
+    "address": "0x488609b7113FCf3B761A05956300d605E8f6BcAf",
+    "startBlock": 3594847
   },
   "nounsDAO": {
-    "address": "0x442961F79C3968f908ed295a5DEbfcD9aC1712B6",
-    "startBlock": 5301556
+    "address": "0x35d2670d7C8931AACdd37C89Ddcb0638c3c44A57",
+    "startBlock": 3594849
   },
   "nounsDAOData": {
-    "address": "0xF82152a4322800E15F14eD85e490Fe12b815E6c3",
-    "startBlock": 5301568
+    "address": "0x9040f720AA8A693F950B9cF94764b4b06079D002",
+    "startBlock": 3691326
   }
 }

--- a/packages/nouns-subgraph/package.json
+++ b/packages/nouns-subgraph/package.json
@@ -28,6 +28,8 @@
     "deploy:goerli": "yarn clean && yarn prepare:goerli && yarn codegen && yarn graph build && goldsky subgraph deploy nouns-v3-goerli/0.1.6",
     "deploy:sepolia": "yarn clean && yarn prepare:sepolia && yarn codegen && yarn graph build && goldsky subgraph deploy nouns-sepolia-client-incentives/0.1.1",
     "deploy:mainnet": "yarn clean && yarn prepare:mainnet && yarn codegen && yarn graph build && goldsky subgraph deploy nouns/0.2.5",
+    "deploy-studio:mainnet": "yarn clean && yarn prepare:mainnet && yarn codegen && yarn graph build && graph deploy --studio nouns",
+    "deploy-studio:sepolia": "yarn clean && yarn prepare:sepolia && yarn codegen && yarn graph build && graph deploy --studio nouns-sepolia",
     "mustache": "mustache"
   },
   "devDependencies": {

--- a/packages/nouns-subgraph/schema.graphql
+++ b/packages/nouns-subgraph/schema.graphql
@@ -76,7 +76,7 @@ type Noun @entity {
 }
 
 type Bid @entity {
-  "Bid transaction hash"
+  "Noun.id-amount"
   id: ID!
 
   "The Noun being bid on"
@@ -90,6 +90,9 @@ type Bid @entity {
 
   "Block number of the bid"
   blockNumber: BigInt!
+
+  "Transaction has for the bid"
+  txHash: Bytes!
 
   "Index of transaction within block"
   txIndex: BigInt!

--- a/packages/nouns-subgraph/src/nouns-auction-house.ts
+++ b/packages/nouns-subgraph/src/nouns-auction-house.ts
@@ -55,6 +55,7 @@ export function handleAuctionBid(event: AuctionBid): void {
   bid.bidder = bidder.id;
   bid.amount = auction.amount;
   bid.noun = auction.noun;
+  bid.txHash = event.transaction.hash;
   bid.txIndex = event.transaction.index;
   bid.blockNumber = event.block.number;
   bid.blockTimestamp = event.block.timestamp;

--- a/packages/nouns-webapp/src/state/slices/pastAuctions.ts
+++ b/packages/nouns-webapp/src/state/slices/pastAuctions.ts
@@ -30,7 +30,7 @@ const reduxSafePastAuctions = (data: any): AuctionState[] => {
           sender: bid.bidder.id,
           value: BigNumber.from(bid.amount).toJSON(),
           extended: false,
-          transactionHash: bid.id,
+          transactionHash: bid.txHash,
           transactionIndex: Number(bid.txIndex),
           timestamp: BigNumber.from(bid.blockTimestamp).toJSON(),
         };

--- a/packages/nouns-webapp/src/wrappers/subgraph.ts
+++ b/packages/nouns-webapp/src/wrappers/subgraph.ts
@@ -10,6 +10,7 @@ export interface IBid {
   amount: BigNumber;
   blockNumber: number;
   blockTimestamp: number;
+  txHash: string;
   txIndex?: number;
   noun: {
     id: number;
@@ -386,6 +387,7 @@ export const latestAuctionsQuery = () => gql`
         amount
         blockNumber
         blockTimestamp
+        txHash
         txIndex
         bidder {
           id


### PR DESCRIPTION
In the current deployment of nouns.wtf, historical auction bid links are broken. 
This is because the etherscan link is using `bid.id` from the subgraph, which is actually `noun.id-amount` and not the transaction hash:
![image](https://github.com/nounsDAO/nouns-monorepo/assets/31705429/4c565b7e-5f84-49b9-bfa6-a45c60f30587)


This `ID` should not be transaction hash as ID's must be unique and it is possible a single transaction may contain multiple bids.

To address this issue, I have added `txHash` into the subgraph for bids, and consumed this change in the webapp. Here is how this now looks locally:

![image](https://github.com/nounsDAO/nouns-monorepo/assets/31705429/a9062263-bf94-4544-96d4-74ff62776c23)


Note that these subgraph changes have already been deployed to the Noun Subgraphs we (Paperclip Labs) maintain on The Graphs decentralized network:
* Mainnet: https://thegraph.com/explorer/subgraphs/5qcR6rAfDMZCVGuZ6DDois7y4zyXqsyqvaqhE6NRRraW?view=Query&chain=arbitrum-one
* Sepolia: https://thegraph.com/explorer/subgraphs/AGjNFPHb2jWUyvSTnZqWn8LzPtLQLpjUXuZNVT812Hvr?view=Query&chain=arbitrum-one

I used these deployments to test the webapp locally, and not the Goldsky subgraphs. Before this PR merges, will need to have the Verbs team update the Goldsky deployments to consume this subgraph change (I don't have the key).

Further, I updated the Sepolia addresses for the subgraph. AFAICT, these addresses are the ones with all the most recent contract versions.