### PR TITLE
Add transaction hashes to relevant governance events

### DIFF
--- a/packages/nouns-subgraph/schema.graphql
+++ b/packages/nouns-subgraph/schema.graphql
@@ -606,6 +606,9 @@ type ProposalCandidateSignature @entity {
 
   "The signature's creation block"
   createdBlock: BigInt!
+
+  "The signature's transaction hash"
+  createdTransactionHash: Bytes!
 }
 
 type ProposalFeedback @entity(immutable: true) {

--- a/packages/nouns-subgraph/schema.graphql
+++ b/packages/nouns-subgraph/schema.graphql
@@ -91,7 +91,7 @@ type Bid @entity {
   "Block number of the bid"
   blockNumber: BigInt!
 
-  "Transaction has for the bid"
+  "Transaction hash for the bid"
   txHash: Bytes!
 
   "Index of transaction within block"
@@ -229,6 +229,9 @@ type Proposal @entity {
   "The proposal creation transaction hash"
   createdTransactionHash: Bytes!
 
+  "The proposal's last update transaction hash"
+  lastUpdatedTransactionHash: Bytes!
+
   "Block number from where the voting starts"
   startBlock: BigInt!
 
@@ -301,11 +304,17 @@ type Proposal @entity {
   "The timestamp when this proposal was canceled"
   canceledTimestamp: BigInt
 
+  "The transaction hash when the proposal was canceled"
+  canceledTransactionHash: Bytes
+
   "The block number at which this proposal was executed"
   executedBlock: BigInt
 
   "The timestamp when this proposal was executed"
   executedTimestamp: BigInt
+
+  "The transaction hash when the proposal was executed"
+  executedTransactionHash: Bytes
 
   "The block number at which this proposal was vetoed"
   vetoedBlock: BigInt
@@ -313,11 +322,17 @@ type Proposal @entity {
   "The timestamp when this proposal was vetoed"
   vetoedTimestamp: BigInt
 
+  "The transaction hash when the proposal was vetoed"
+  vetoedTransactionHash: Bytes
+
   "The block number at which this proposal was queued"
   queuedBlock: BigInt
 
   "The timestamp when this proposal was queued"
   queuedTimestamp: BigInt
+
+  "The transaction hash when the proposal was queued"
+  queuedTransactionHash: Bytes
 
   "The ID of the client that facilitated this proposal"
   clientId: Int!
@@ -334,6 +349,9 @@ type ProposalVersion @entity(immutable: true) {
 
   "The block timestamp of the update"
   createdAt: BigInt!
+
+  "The transaction hash of the update"
+  createdTransactionHash: Bytes!
 
   "Targets data for the change"
   targets: [Bytes!]
@@ -390,6 +408,9 @@ type Vote @entity {
 
   "The timestamp of the block the vote is in"
   blockTimestamp: BigInt!
+
+  "The transaction hash of the vote"
+  transactionHash: Bytes!
 
   "The ID of the client that facilitated this vote"
   clientId: Int!
@@ -480,6 +501,9 @@ type ProposalCandidate @entity {
 
   "The block number at which this candidate was canceled"
   canceledBlock: BigInt
+
+  "The transaction hash at which this candidate was canceled"
+  canceledTransactionHash: Bytes
 
   "Latest version of the proposal"
   latestVersion: ProposalCandidateVersion!

--- a/packages/nouns-subgraph/src/nouns-dao-data.ts
+++ b/packages/nouns-subgraph/src/nouns-dao-data.ts
@@ -91,6 +91,7 @@ export function handleProposalCandidateCanceled(event: ProposalCandidateCanceled
   candidate.canceled = true;
   candidate.canceledTimestamp = event.block.timestamp;
   candidate.canceledBlock = event.block.number;
+  candidate.canceledTransactionHash = event.transaction.hash;
 
   candidate.save();
 }

--- a/packages/nouns-subgraph/src/nouns-dao-data.ts
+++ b/packages/nouns-subgraph/src/nouns-dao-data.ts
@@ -126,6 +126,7 @@ export function handleSignatureAdded(event: SignatureAdded): void {
   candidateSig.reason = event.params.reason;
   candidateSig.createdBlock = event.block.number;
   candidateSig.createdTimestamp = event.block.timestamp;
+  candidateSig.createdTransactionHash = event.transaction.hash;
 
   candidateSig.save();
 }

--- a/packages/nouns-subgraph/src/nouns-dao.ts
+++ b/packages/nouns-subgraph/src/nouns-dao.ts
@@ -75,6 +75,7 @@ export function handleProposalCreated(event: ProposalCreated): void {
   proposal.createdBlock = event.block.number;
   proposal.lastUpdatedTimestamp = event.block.timestamp;
   proposal.lastUpdatedBlock = event.block.number;
+  proposal.lastUpdatedTransactionHash = event.transaction.hash;
   proposal.createdTransactionHash = event.transaction.hash;
   proposal.startBlock = event.params.startBlock;
   proposal.endBlock = event.params.endBlock;
@@ -182,6 +183,7 @@ export function handleProposalUpdated(event: ProposalUpdated): void {
   // Then update the proposal to the latest state
   proposal.lastUpdatedTimestamp = event.block.timestamp;
   proposal.lastUpdatedBlock = event.block.number;
+  proposal.lastUpdatedTransactionHash = event.transaction.hash;
   proposal.targets = changetype<Bytes[]>(event.params.targets);
   proposal.values = event.params.values;
   proposal.signatures = event.params.signatures;
@@ -243,6 +245,7 @@ export function handleProposalCanceled(event: ProposalCanceled): void {
   proposal.status = STATUS_CANCELLED;
   proposal.canceledBlock = event.block.number;
   proposal.canceledTimestamp = event.block.timestamp;
+  proposal.canceledTransactionHash = event.transaction.hash;
   proposal.save();
 }
 
@@ -252,6 +255,7 @@ export function handleProposalVetoed(event: ProposalVetoed): void {
   proposal.status = STATUS_VETOED;
   proposal.vetoedBlock = event.block.number;
   proposal.vetoedTimestamp = event.block.timestamp;
+  proposal.vetoedTransactionHash = event.transaction.hash;
   proposal.save();
 }
 
@@ -263,6 +267,7 @@ export function handleProposalQueued(event: ProposalQueued): void {
   proposal.executionETA = event.params.eta;
   proposal.queuedBlock = event.block.number;
   proposal.queuedTimestamp = event.block.timestamp;
+  proposal.queuedTransactionHash = event.transaction.hash;
   proposal.save();
 
   governance.proposalsQueued = governance.proposalsQueued.plus(BIGINT_ONE);
@@ -277,6 +282,7 @@ export function handleProposalExecuted(event: ProposalExecuted): void {
   proposal.executionETA = null;
   proposal.executedBlock = event.block.number;
   proposal.executedTimestamp = event.block.timestamp;
+  proposal.executedTransactionHash = event.transaction.hash;
   proposal.save();
 
   governance.proposalsQueued = governance.proposalsQueued.minus(BIGINT_ONE);
@@ -301,6 +307,7 @@ export function handleVoteCast(event: VoteCast): void {
   vote.nouns = voter.nounsRepresented;
   vote.blockNumber = event.block.number;
   vote.blockTimestamp = event.block.timestamp;
+  vote.transactionHash = event.transaction.hash;
 
   if (event.params.reason != '') {
     vote.reason = event.params.reason;
@@ -399,6 +406,7 @@ function captureProposalVersion(
   previousVersion.proposal = proposal.id;
   previousVersion.createdBlock = proposal.lastUpdatedBlock!;
   previousVersion.createdAt = proposal.lastUpdatedTimestamp!;
+  previousVersion.createdTransactionHash = proposal.lastUpdatedTransactionHash!;
   previousVersion.targets = proposal.targets;
   previousVersion.values = proposal.values;
   previousVersion.signatures = proposal.signatures;


### PR DESCRIPTION
Useful for nouns clients to link to the specific transaction on-chain.