### PR TITLE
Switch to @noundry/nouns-assets

### DIFF
--- a/packages/nouns-webapp/package.json
+++ b/packages/nouns-webapp/package.json
@@ -15,7 +15,7 @@
     "@lingui/macro": "3.13.3",
     "@lingui/react": "3.13.3",
     "@netlify/functions": "^0.7.2",
-    "@nomonouns/assets": "0.11.0",
+    "@noundry/nouns-assets": "^1.0.0",
     "@nouns/sdk": "^0.4.0",
     "@reduxjs/toolkit": "^1.6.0",
     "@testing-library/jest-dom": "^5.11.4",

--- a/packages/nouns-webapp/public/index.html
+++ b/packages/nouns-webapp/public/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+    <script src="https://assets.noundry.wtf/nouns/image-data.js" />
     <meta charset="utf-8" />
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
     <script defer data-domain="nouns.wtf" src="https://plausible.io/js/plausible.js"></script>

--- a/packages/nouns-webapp/src/components/ExploreGrid/ExploreNounDetail/index.tsx
+++ b/packages/nouns-webapp/src/components/ExploreGrid/ExploreNounDetail/index.tsx
@@ -3,7 +3,7 @@ import { useNounSeed } from '../../../wrappers/nounToken';
 import { BigNumber } from 'ethers';
 import { StandalonePart } from '../../StandalonePart';
 import classes from './ExploreNounDetail.module.css';
-import { ImageData } from '@nomonouns/assets';
+import { ImageData } from '@noundry/nouns-assets';
 import { Trans } from '@lingui/macro';
 import { AnimatePresence, motion } from 'framer-motion/dist/framer-motion';
 import { XIcon } from '@heroicons/react/solid';

--- a/packages/nouns-webapp/src/components/StandaloneNoun/index.tsx
+++ b/packages/nouns-webapp/src/components/StandaloneNoun/index.tsx
@@ -1,4 +1,4 @@
-import { ImageData as data, getNounData } from '@nomonouns/assets';
+import { ImageData as data, getNounData } from '@noundry/nouns-assets';
 import { buildSVG } from '@nouns/sdk';
 import { BigNumber as EthersBN } from 'ethers';
 import { INounSeed, useNounSeed } from '../../wrappers/nounToken';

--- a/packages/nouns-webapp/src/components/StandalonePart/index.tsx
+++ b/packages/nouns-webapp/src/components/StandalonePart/index.tsx
@@ -1,4 +1,4 @@
-import { ImageData as imageData, getPartData } from '@nomonouns/assets';
+import { ImageData as imageData, getPartData } from '@noundry/nouns-assets';
 import { buildSVG } from '@nouns/sdk';
 import Image from 'react-bootstrap/Image';
 import classes from './StandalonePart.module.css';

--- a/packages/nouns-webapp/src/pages/Playground/index.tsx
+++ b/packages/nouns-webapp/src/pages/Playground/index.tsx
@@ -12,7 +12,7 @@ import {
 import classes from './Playground.module.css';
 import React, { ChangeEvent, ReactNode, useEffect, useRef, useState } from 'react';
 import Link from '../../components/Link';
-import { ImageData, getNounData, getRandomNounSeed } from '@nomonouns/assets';
+import { ImageData, getNounData, getRandomNounSeed } from '@noundry/nouns-assets';
 import { buildSVG, EncodedImage, PNGCollectionEncoder } from '@nouns/sdk';
 import InfoIcon from '../../assets/icons/Info.svg';
 import Noun from '../../components/Noun';

--- a/yarn.lock
+++ b/yarn.lock
@@ -4546,14 +4546,13 @@
     "@types/sinon-chai" "^3.2.3"
     "@types/web3" "1.0.19"
 
-"@nomonouns/assets@0.11.0":
-  version "0.11.0"
-  resolved "https://registry.yarnpkg.com/@nomonouns/assets/-/assets-0.11.0.tgz#736a41343d5a4c710cec8644764db1c3d4b9913a"
-  integrity sha512-/jD4UfMR7OTScuAJBM9g3BqYZ3z9nXWLopPR5+QYfh30446P4d/4R2mzYa/7tz4/YZQlGX0kw+IcSy1ofTh+BA==
+"@noundry/nouns-assets@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@noundry/nouns-assets/-/nouns-assets-1.0.0.tgz#f6508aeee2ca0a5a362e0c279eeb254b34ba0110"
+  integrity sha512-PFzJypAQAyQMe/WTyjLUpmdfXf/RPyXqD5C9jfIjMqVRUeBBfAl2Skt/W3xpbgjLtZlGfiEzpjZEvujen271fw==
   dependencies:
     "@ethersproject/bignumber" "^5.5.0"
     "@ethersproject/solidity" "^5.5.0"
-    pako "^2.1.0"
 
 "@npmcli/fs@^1.0.0":
   version "1.0.0"
@@ -19419,11 +19418,6 @@ package-json@^6.3.0:
     registry-auth-token "^4.0.0"
     registry-url "^5.0.0"
     semver "^6.2.0"
-
-pako@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/pako/-/pako-2.1.0.tgz#266cc37f98c7d883545d11335c00fbd4062c9a86"
-  integrity sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==
 
 pako@~1.0.5:
   version "1.0.11"


### PR DESCRIPTION
nouns.wtf is out of date again, missing the [Lilac body](https://www.nouns.camp/proposals/741)

This PR switches from the @nomonouns/assets package to @noundry/nouns-assets
that is a slightly modified version of @nouns/assets which [uses more up-to-date assets if available](https://github.com/volkyeth/noundry/blob/26f4307fb9743c329771dc2a755e06b1857c82ae/packages/nouns-assets/src/image-data.ts#L12-L14), and fallbacks to the package assets.

It also adds a script fetching the latest assets from https://assets.noundry.wtf/nouns/image-data.js
this script injects the most up-to-date assets for @noundry/nouns-assets to use.

Those assets are generated directly from the onchain data, so they'll always be up-to-date. No more need to update the package and push a new deployment all the time.

As a proof of concept, the current image-data.json from @noundry/nouns-assets [does not contain the Lilac body](https://github.com/volkyeth/noundry/blob/26f4307fb9743c329771dc2a755e06b1857c82ae/packages/nouns-assets/src/image-data.json#L362-L366). It is nevertheless loaded from the assets.noundry.wtf API and is available on the app:

![CleanShot 2025-02-17 at 14 50 37@2x](https://github.com/user-attachments/assets/4e32d83f-73c9-4a20-a27d-317f72381fd5)
(tested locally)

Obs: although this solution adds a dependency to the assets.noundry.wtf API, in a scenario where it's unavailable, the app will still load as usual, falling back to the assets included with @noundry/nouns-assets
