### PR TITLE
ci: bump actions/checkout to v4

### DIFF
--- a/.github/workflows/contract-deployment.yaml
+++ b/.github/workflows/contract-deployment.yaml
@@ -10,7 +10,7 @@ jobs:
     name: Build and Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Use Node.js 16.x
         uses: actions/setup-node@v1
         with:

--- a/.github/workflows/contracts.yaml
+++ b/.github/workflows/contracts.yaml
@@ -20,7 +20,7 @@ jobs:
     name: Build and Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Use Node.js 16.x

--- a/.github/workflows/node.yaml
+++ b/.github/workflows/node.yaml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         node-version: [16.x]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1
         with:

--- a/.github/workflows/subgraph-test.yaml
+++ b/.github/workflows/subgraph-test.yaml
@@ -16,7 +16,7 @@ jobs:
     name: Build and Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Use Node.js 16.x


### PR DESCRIPTION
Hey ! GitHub‑hosted runners now use Node 20, so checkout v4 is required
This PR updates all workflows to actions/checkout@v4 , no functional changes expected