### PR TITLE
fix dead link NounsI18nProvider.tsx

### DIFF
--- a/packages/nouns-webapp/src/i18n/NounsI18nProvider.tsx
+++ b/packages/nouns-webapp/src/i18n/NounsI18nProvider.tsx
@@ -1,6 +1,3 @@
-/**
- * NounsI18nProvider.tsx is a modified version of https://github.com/Uniswap/interface/blob/main/packages/uniswap/src/i18n/i18n-setup.tsx
- */
 import { i18n } from '@lingui/core';
 import { I18nProvider } from '@lingui/react';
 import { DEFAULT_LOCALE, SupportedLocale } from './locales';

--- a/packages/nouns-webapp/src/i18n/NounsI18nProvider.tsx
+++ b/packages/nouns-webapp/src/i18n/NounsI18nProvider.tsx
@@ -1,5 +1,5 @@
 /**
- * NounsI18nProvider.tsx is a modified version of https://github.com/Uniswap/interface/blob/main/src/lib/i18n.tsx
+ * NounsI18nProvider.tsx is a modified version of https://github.com/Uniswap/interface/blob/main/packages/uniswap/src/i18n/i18n-setup.tsx
  */
 import { i18n } from '@lingui/core';
 import { I18nProvider } from '@lingui/react';


### PR DESCRIPTION
Hey team—noticed a dead link, replaced it with a working URL

https://github.com/Uniswap/interface/blob/main/src/lib/i18n.tsx - old
https://github.com/Uniswap/interface/blob/main/packages/uniswap/src/i18n/i18n-setup.tsx - new link