### PR TITLE
Remove docs from nav

### DIFF
--- a/packages/nouns-webapp/public/_redirects
+++ b/packages/nouns-webapp/public/_redirects
@@ -1,2 +1,0 @@
-/docs	https://nouns.notion.site/Explore-Nouns-a2a9dceeb1d54e10b9cbf3f931c2266f	302
-/*    /index.html   200

--- a/packages/nouns-webapp/src/components/NavBar/index.tsx
+++ b/packages/nouns-webapp/src/components/NavBar/index.tsx
@@ -1,12 +1,6 @@
 import { useState } from 'react';
 
-import {
-  faBookOpen,
-  faFile,
-  faPenToSquare,
-  faPlay,
-  faUsers,
-} from '@fortawesome/free-solid-svg-icons';
+import { faFile, faPenToSquare, faPlay, faUsers } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Trans } from '@lingui/react/macro';
 import clsx from 'clsx';
@@ -28,7 +22,6 @@ import { useAppSelector } from '@/hooks';
 import { useTreasuryBalance } from '@/hooks/useTreasuryBalance';
 import { usePickByState } from '@/utils/colorResponsiveUIUtils';
 import { buildEtherscanAddressLink } from '@/utils/etherscan';
-import { ExternalURL, externalURL } from '@/utils/externalURL';
 import { Address } from '@/utils/types';
 import { defaultChain } from '@/wagmi';
 import { useIsDaoGteV3 } from '@/wrappers/nounsDao';
@@ -173,19 +166,6 @@ const NavBar = () => {
                 </Nav.Link>
               )}
             </div>
-            <Nav.Link
-              href={externalURL(ExternalURL.nounsCenter)}
-              className={classes.nounsNavLink}
-              target="_blank"
-              rel="noreferrer"
-              onClick={closeNav}
-            >
-              <NavBarButton
-                buttonText={<Trans>Docs</Trans>}
-                buttonIcon={<FontAwesomeIcon icon={faBookOpen} />}
-                buttonStyle={nonWalletButtonStyle}
-              />
-            </Nav.Link>
             <div className={clsx(responsiveUiUtilsClasses.mobileOnly)}>
               <Nav.Link
                 as={Link}

--- a/packages/nouns-webapp/src/components/Winner/Winner.module.css
+++ b/packages/nouns-webapp/src/components/Winner/Winner.module.css
@@ -21,26 +21,6 @@
   cursor: pointer;
 }
 
-.verifyButton {
-  height: 3rem;
-  color: white;
-  border: transparent;
-  background-color: var(--brand-black);
-  font-family: 'PT Root UI';
-  font-weight: bold;
-  border-radius: 8px;
-  font-size: 16px;
-}
-
-.verifyButton:hover,
-.verifyButton:active,
-.verifyButton:focus,
-.verifyButton:disabled {
-  background-color: gray !important;
-  outline: none !important;
-  box-shadow: none !important;
-}
-
 .section h4 {
   font-family: 'PT Root UI';
   font-size: 18px;
@@ -95,19 +75,6 @@
     width: 100%;
     margin-left: 0;
     margin-right: 0;
-  }
-
-  .verifyButton {
-    width: 100%;
-    height: 3rem;
-    border-radius: 10px;
-    font-weight: bold;
-    font-size: 18px;
-  }
-
-  .verifyLink {
-    padding-left: 1.25rem;
-    padding-right: 1.25rem;
   }
 
   .youCopy {

--- a/packages/nouns-webapp/src/components/Winner/index.tsx
+++ b/packages/nouns-webapp/src/components/Winner/index.tsx
@@ -4,14 +4,13 @@ import React from 'react';
 
 import { Trans } from '@lingui/react/macro';
 import clsx from 'clsx';
-import { Button, Col, Row } from 'react-bootstrap';
+import { Col, Row } from 'react-bootstrap';
 
 import ShortAddress from '@/components/ShortAddress';
 import Tooltip from '@/components/Tooltip';
 import { useAppSelector } from '@/hooks';
 import { useActiveLocale } from '@/hooks/useActivateLocale';
 import { buildEtherscanAddressLink } from '@/utils/etherscan';
-import { isMobileScreen } from '@/utils/isMobile';
 
 import classes from './Winner.module.css';
 
@@ -25,7 +24,6 @@ const Winner: React.FC<WinnerProps> = props => {
   const activeAccount = useAppSelector(state => state.account.activeAccount);
 
   const isCool = useAppSelector(state => state.application.isCoolBackground);
-  const isMobile = isMobileScreen();
 
   const isWinnerYou =
     activeAccount !== undefined && activeAccount.toLocaleLowerCase() === winner.toLocaleLowerCase();
@@ -44,20 +42,6 @@ const Winner: React.FC<WinnerProps> = props => {
           <Trans>You</Trans>
         </h2>
       </Col>
-      {!isMobile && (
-        <Col>
-          <a
-            href="https://www.nounsagora.com/"
-            target="_blank"
-            rel="noreferrer noopener"
-            className={classes.verifyLink}
-          >
-            <Button className={classes.verifyButton}>
-              <Trans>Delegate</Trans>
-            </Button>
-          </a>
-        </Col>
-      )}
     </Row>
   ) : (
     <ShortAddress size={40} address={winner} avatar={true} />
@@ -106,20 +90,6 @@ const Winner: React.FC<WinnerProps> = props => {
           </h2>
         </Col>
       </Row>
-      {isWinnerYou && isMobile && (
-        <Row>
-          <a
-            href="https://www.nounsagora.com/"
-            target="_blank"
-            rel="noreferrer noopener"
-            className={classes.verifyLink}
-          >
-            <Button className={classes.verifyButton}>
-              <Trans>Delegate</Trans>
-            </Button>
-          </a>
-        </Row>
-      )}
     </>
   );
 };

--- a/packages/nouns-webapp/src/components/Winner/index.tsx
+++ b/packages/nouns-webapp/src/components/Winner/index.tsx
@@ -47,16 +47,6 @@ const Winner: React.FC<WinnerProps> = props => {
       {!isMobile && (
         <Col>
           <a
-            href="https://nouns.center/groups"
-            target="_blank"
-            rel="noreferrer noopener"
-            className={classes.verifyLink}
-          >
-            <Button className={classes.verifyButton}>
-              <Trans>Get Involved</Trans>
-            </Button>
-          </a>
-          <a
             href="https://www.nounsagora.com/"
             target="_blank"
             rel="noreferrer noopener"
@@ -118,16 +108,6 @@ const Winner: React.FC<WinnerProps> = props => {
       </Row>
       {isWinnerYou && isMobile && (
         <Row>
-          <a
-            href="https://nouns.center/groups"
-            target="_blank"
-            rel="noreferrer noopener"
-            className={classes.verifyLink}
-          >
-            <Button className={classes.verifyButton}>
-              <Trans>Get Involved</Trans>
-            </Button>
-          </a>
           <a
             href="https://www.nounsagora.com/"
             target="_blank"

--- a/packages/nouns-webapp/src/utils/externalURL.ts
+++ b/packages/nouns-webapp/src/utils/externalURL.ts
@@ -2,7 +2,6 @@ export enum ExternalURL {
   twitter,
   notion,
   farcaster,
-  nounsCenter,
 }
 
 export const externalURL = (externalURL: ExternalURL) => {
@@ -13,7 +12,5 @@ export const externalURL = (externalURL: ExternalURL) => {
       return 'https://nouns.notion.site/Explore-Nouns-a2a9dceeb1d54e10b9cbf3f931c2266f';
     case ExternalURL.farcaster:
       return 'https://warpcast.com/~/channel/nouns/';
-    case ExternalURL.nounsCenter:
-      return 'https://nouns.center/';
   }
 };


### PR DESCRIPTION
Closes #1003 

nouns.center is severely outdated, and most of the content is currently misleading (outdated protocol docs, outdated funding tracks like NSFW, links to discontinued platforms, etc). Since updating it is not trivial (lot of content on notion pages we don't control), will remove for now

will be added back in the future with the new knowledge base