### PR TITLE
fix: correct typos in Nouns contracts and subgraph tests

### DIFF
--- a/packages/nouns-contracts/tasks/deploy-local-dao-v3.ts
+++ b/packages/nouns-contracts/tasks/deploy-local-dao-v3.ts
@@ -255,7 +255,7 @@ task('deploy-local-dao-v3', 'Deploy contracts to hardhat')
 
     if (expectedAuctionHouseProxyAddress !== contracts.NounsAuctionHouseProxy.instance?.address) {
       console.log(
-        `wrong auctio house proxy address expected: ${expectedAuctionHouseProxyAddress} actual: ${contracts.NounsAuctionHouseProxy.instance?.address}`,
+        `wrong auction house proxy address expected: ${expectedAuctionHouseProxyAddress} actual: ${contracts.NounsAuctionHouseProxy.instance?.address}`,
       );
       throw 'wrong address';
     }

--- a/packages/nouns-subgraph/tests/nouns-dao-data.test.ts
+++ b/packages/nouns-subgraph/tests/nouns-dao-data.test.ts
@@ -181,7 +181,7 @@ describe('nouns-dao-data', () => {
       assert.assertNull(signature);
     });
 
-    test('save a proposal candidade includes candidate index', () => {
+    test('save a proposal candidate includes candidate index', () => {
       const candidate = ProposalCandidate.load(
         candidateProposer.toHexString().concat('-').concat(slug),
       )!;


### PR DESCRIPTION
packages/nouns-contracts/tasks/deploy-local-dao-v3.ts: fixed typo in console log message (auctio → auction).

packages/nouns-subgraph/tests/nouns-dao-data.test.ts: corrected typo in test description (candidade → candidate).