### PR TITLE
Fix Typos in Comment

### DIFF
--- a/packages/nouns-sdk/README.md
+++ b/packages/nouns-sdk/README.md
@@ -24,7 +24,7 @@ You can check the linked contracts above for all the available methods.
 They're generated from the contract ABIs and include type-safe methods for all of the read and write functions.
 
 > [!TIP]
-> To get full IDE completions on the contract methods, ensure you have `strict` mode enabled in your `tsconfig.json` and that you fullfill all the [wagmi requirements](https://wagmi.sh/core/typescript#requirements)
+> To get full IDE completions on the contract methods, ensure you have `strict` mode enabled in your `tsconfig.json` and that you fulfill all the [wagmi requirements](https://wagmi.sh/core/typescript#requirements)
 
 #### Actions
 

--- a/packages/nouns-webapp/src/subgraphs/graphql.ts
+++ b/packages/nouns-webapp/src/subgraphs/graphql.ts
@@ -911,7 +911,7 @@ export type DynamicQuorumParams = {
   __typename?: 'DynamicQuorumParams';
   /** The block from which proposals are using DQ, based on when we first see configuration being set */
   dynamicQuorumStartBlock?: Maybe<Scalars['BigInt']['output']>;
-  /** Unique entity used to store the latest dymanic quorum params */
+  /** Unique entity used to store the latest dynamic quorum params */
   id: Scalars['ID']['output'];
   /** Max quorum basis points */
   maxQuorumVotesBPS: Scalars['Int']['output'];


### PR DESCRIPTION
### Description

This PR corrects several minor typos in comments and documentation across the codebase. The changes are non-functional and purely textual to improve clarity and maintain a clean, professional codebase.

### Details

- Corrected misspellings:
  - `fullfill` → `fulfill`
  - `dymanic` → `dynamic`

These fixes help enhance readability and eliminate minor distractions during development and code reviews.

### Additional Info

No logic or functionality has been modified. All changes are restricted to comments or non-executable doc annotations.