### PR TITLE
Fix token buyer CI checks

### DIFF
--- a/packages/nouns-webapp/src/components/BrandTextEntry/index.tsx
+++ b/packages/nouns-webapp/src/components/BrandTextEntry/index.tsx
@@ -16,7 +16,16 @@ interface BrandTextEntryProps {
 }
 
 const BrandTextEntry: React.FC<BrandTextEntryProps> = props => {
-  const { onChange, value, placeholder, type, min, label, isInvalid = false, disabled = false } = props;
+  const {
+    onChange,
+    value,
+    placeholder,
+    type,
+    min,
+    label,
+    isInvalid = false,
+    disabled = false,
+  } = props;
 
   return (
     <div className={classes.container}>

--- a/packages/nouns-webapp/src/components/ProposalActionsModal/index.tsx
+++ b/packages/nouns-webapp/src/components/ProposalActionsModal/index.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/strict-boolean-expressions */
 import type { Abi } from 'viem';
 
 import React, { SetStateAction, useState } from 'react';

--- a/packages/nouns-webapp/src/components/ProposalActionsModal/steps/FunctionCallEnterArgsStep/index.tsx
+++ b/packages/nouns-webapp/src/components/ProposalActionsModal/steps/FunctionCallEnterArgsStep/index.tsx
@@ -1,11 +1,12 @@
+/* eslint-disable @typescript-eslint/strict-boolean-expressions */
 import type { ProposalActionModalStepProps } from '@/components/ProposalActionsModal';
 import type { Abi, AbiFunction } from 'viem';
-import { encodeFunctionData, getAbiItem } from 'viem';
 
 import React, { useEffect, useState } from 'react';
 
 import { Trans } from '@lingui/react/macro';
 import { Col, FormControl, FormGroup, InputGroup, Row } from 'react-bootstrap';
+import { encodeFunctionData, getAbiItem } from 'viem';
 
 import 'bs-custom-file-input';
 import 'react-stepz/dist/index.css';

--- a/packages/nouns-webapp/src/components/ProposalActionsModal/steps/TransferFundsDetailsStep/index.tsx
+++ b/packages/nouns-webapp/src/components/ProposalActionsModal/steps/TransferFundsDetailsStep/index.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/strict-boolean-expressions */
 import React, { useEffect, useState } from 'react';
 
 import { Trans } from '@lingui/react/macro';

--- a/packages/nouns-webapp/src/components/ProposalTransactions/index.tsx
+++ b/packages/nouns-webapp/src/components/ProposalTransactions/index.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/strict-boolean-expressions */
 import { Col, OverlayTrigger, Popover, Row } from 'react-bootstrap';
 import { decodeFunctionData, formatEther, parseAbi } from 'viem';
 
@@ -86,43 +87,43 @@ const ProposalTransactions = ({
   return (
     <div className={className}>
       {proposalTransactions.map((tx, i) => (
-          <OverlayTrigger
-            key={`${tx.signature}-${tx.calldata}`}
-            trigger={['hover', 'focus']}
-            placement="top"
-            overlay={getPopover(tx)}
-          >
+        <OverlayTrigger
+          key={`${tx.signature}-${tx.calldata}`}
+          trigger={['hover', 'focus']}
+          placement="top"
+          overlay={getPopover(tx)}
+        >
           <div
             className={`${classes.transactionDetails} d-flex justify-content-between align-items-center`}
           >
-              <div>
-                <span>Transaction #{i + 1} - </span>
-                <span>
-                  <b>{tx.signature || 'transfer()'}</b>
-                </span>
-              </div>
-              <div className={classes.actions}>
-                {onEditProposalTransaction &&
-                  (tx.proposalActionState as { actionType?: string } | undefined)?.actionType !==
-                    'Stream Funds' && (
-                    <button
-                      type="button"
-                      className={classes.editTransactionButton}
-                      onClick={() => onEditProposalTransaction(i)}
-                    >
-                      Edit
-                    </button>
-                  )}
-                <button
-                  type="button"
-                  className={classes.removeTransactionButton}
-                  onClick={() => onRemoveProposalTransaction(i)}
-                >
-                  <img src={xIcon} alt="Remove Transaction" />
-                </button>
-              </div>
+            <div>
+              <span>Transaction #{i + 1} - </span>
+              <span>
+                <b>{tx.signature || 'transfer()'}</b>
+              </span>
             </div>
-          </OverlayTrigger>
+            <div className={classes.actions}>
+              {onEditProposalTransaction &&
+                (tx.proposalActionState as { actionType?: string } | undefined)?.actionType !==
+                  'Stream Funds' && (
+                  <button
+                    type="button"
+                    className={classes.editTransactionButton}
+                    onClick={() => onEditProposalTransaction(i)}
+                  >
+                    Edit
+                  </button>
+                )}
+              <button
+                type="button"
+                className={classes.removeTransactionButton}
+                onClick={() => onRemoveProposalTransaction(i)}
+              >
+                <img src={xIcon} alt="Remove Transaction" />
+              </button>
+            </div>
+          </div>
+        </OverlayTrigger>
       ))}
     </div>
   );

--- a/packages/nouns-webapp/src/components/TokenBuyerTopUpAlert/index.tsx
+++ b/packages/nouns-webapp/src/components/TokenBuyerTopUpAlert/index.tsx
@@ -1,13 +1,10 @@
 import { useEffect } from 'react';
+
 import { Alert, Form } from 'react-bootstrap';
 import { formatEther, formatUnits } from 'viem';
 import { useBalance } from 'wagmi';
 
-import {
-  nounsPayerAddress,
-  nounsTreasuryAddress,
-  useReadUsdcBalanceOf,
-} from '@/contracts';
+import { nounsPayerAddress, nounsTreasuryAddress, useReadUsdcBalanceOf } from '@/contracts';
 import { defaultChain } from '@/wagmi';
 
 import classes from './TokenBuyerTopUpAlert.module.css';
@@ -22,18 +19,23 @@ interface TokenBuyerTopUpAlertProps {
 
 const formatUSDC = (value?: bigint | number) => {
   if (value === undefined) return 'Loading';
-  const formatted = typeof value === 'bigint' ? formatUnits(value, 6) : (value / 1_000_000).toString();
+  const formatted =
+    typeof value === 'bigint' ? formatUnits(value, 6) : (value / 1_000_000).toString();
   return Intl.NumberFormat(undefined, { maximumFractionDigits: 2 }).format(Number(formatted));
 };
 
 const formatSuggestedEth = (value?: string) => {
   if (!value || value === '0') return '0';
-  return Intl.NumberFormat(undefined, { maximumFractionDigits: 4 }).format(Number(formatEther(BigInt(value))));
+  return Intl.NumberFormat(undefined, { maximumFractionDigits: 4 }).format(
+    Number(formatEther(BigInt(value))),
+  );
 };
 
 const formatTreasuryEth = (value?: bigint) => {
   if (value === undefined) return 'Loading';
-  return Intl.NumberFormat(undefined, { maximumFractionDigits: 4 }).format(Number(formatEther(value)));
+  return Intl.NumberFormat(undefined, { maximumFractionDigits: 4 }).format(
+    Number(formatEther(value)),
+  );
 };
 
 const TokenBuyerTopUpAlert = ({
@@ -46,7 +48,8 @@ const TokenBuyerTopUpAlert = ({
   const chainId = defaultChain.id;
   const payerAddress = nounsPayerAddress[chainId];
   const treasuryAddress = nounsTreasuryAddress[chainId];
-  const displayedEth = includeTokenBuyerTopUp && topUpEth && topUpEth !== '0' ? topUpEth : suggestedEth;
+  const displayedEth =
+    includeTokenBuyerTopUp && topUpEth && topUpEth !== '0' ? topUpEth : suggestedEth;
   const displayedEthValue = displayedEth ? BigInt(displayedEth) : 0n;
 
   const { data: payerUSDCBalance } = useReadUsdcBalanceOf({
@@ -76,8 +79,8 @@ const TokenBuyerTopUpAlert = ({
         label={
           <>
             Top up the Token Buyer with{' '}
-            <span className={classes.ethAmount}>{formatSuggestedEth(displayedEth)} ETH</span>
-            . (Optional)
+            <span className={classes.ethAmount}>{formatSuggestedEth(displayedEth)} ETH</span>.
+            (Optional)
           </>
         }
         checked={includeTokenBuyerTopUp}

--- a/packages/nouns-webapp/src/locales/en-US.po
+++ b/packages/nouns-webapp/src/locales/en-US.po
@@ -30,6 +30,10 @@ msgstr "bodies ({0})"
 msgid "This will clear all previous sponsors and feedback votes"
 msgstr "This will clear all previous sponsors and feedback votes"
 
+#: src/components/ProposalActionsModal/steps/TransferFundsDetailsStep/index.tsx
+msgid "Edit Token Buyer Top-Up"
+msgstr "Edit Token Buyer Top-Up"
+
 #: src/components/Documentation/index.tsx
 msgid "Because 100% of Noun auction proceeds are sent to Nouns DAO, Nounders have chosen to compensate themselves with Nouns. Every 10th Noun for the first 5 years of the project (Noun ids #0, #10, #20, #30 and so on) will be automatically sent to the Nounder's multisig to be vested and shared among the founding members of the project."
 msgstr "Because 100% of Noun auction proceeds are sent to Nouns DAO, Nounders have chosen to compensate themselves with Nouns. Every 10th Noun for the first 5 years of the project (Noun ids #0, #10, #20, #30 and so on) will be automatically sent to the Nounder's multisig to be vested and shared among the founding members of the project."
@@ -606,11 +610,7 @@ msgid "Proposal Executed!"
 msgstr "Proposal Executed!"
 
 #: src/pages/EditProposal/index.tsx
-#: src/pages/EditProposal/index.tsx
 #: src/pages/EditCandidate/index.tsx
-#: src/pages/EditCandidate/index.tsx
-#: src/pages/CreateProposal/index.tsx
-#: src/pages/CreateCandidate/index.tsx
 msgid "Note"
 msgstr "Note"
 
@@ -1320,8 +1320,8 @@ msgstr "Auction"
 #: src/pages/EditProposal/index.tsx
 #: src/pages/EditCandidate/index.tsx
 #: src/pages/CreateCandidate/index.tsx
-msgid "Because this proposal contains a USDC fund transfer action we've added an additional ETH transaction to refill the TokenBuyer contract. This action allows to DAO to continue to trustlessly acquire USDC to fund proposals like this."
-msgstr "Because this proposal contains a USDC fund transfer action we've added an additional ETH transaction to refill the TokenBuyer contract. This action allows to DAO to continue to trustlessly acquire USDC to fund proposals like this."
+#~ msgid "Because this proposal contains a USDC fund transfer action we've added an additional ETH transaction to refill the TokenBuyer contract. This action allows to DAO to continue to trustlessly acquire USDC to fund proposals like this."
+#~ msgstr "Because this proposal contains a USDC fund transfer action we've added an additional ETH transaction to refill the TokenBuyer contract. This action allows to DAO to continue to trustlessly acquire USDC to fund proposals like this."
 
 #: src/components/ProposalActionsModal/steps/StreamPaymentsReviewStep/index.tsx
 msgid "Stream"
@@ -1687,8 +1687,8 @@ msgid "Forking"
 msgstr "Forking"
 
 #: src/pages/CreateProposal/index.tsx
-msgid "Because this proposal contains a USDC fund transfer action we've added an additional additional ETH transaction to refill the TokenBuyer contract. This action allows to continue to trustlessly acquire USDC to fund proposals like this."
-msgstr "Because this proposal contains a USDC fund transfer action we've added an additional additional ETH transaction to refill the TokenBuyer contract. This action allows to continue to trustlessly acquire USDC to fund proposals like this."
+#~ msgid "Because this proposal contains a USDC fund transfer action we've added an additional additional ETH transaction to refill the TokenBuyer contract. This action allows to continue to trustlessly acquire USDC to fund proposals like this."
+#~ msgstr "Because this proposal contains a USDC fund transfer action we've added an additional additional ETH transaction to refill the TokenBuyer contract. This action allows to continue to trustlessly acquire USDC to fund proposals like this."
 
 #. placeholder {0}: createCandidateCost ? formatEther(createCandidateCost) : '0'
 #: src/pages/CreateCandidate/index.tsx

--- a/packages/nouns-webapp/src/locales/ja-JP.po
+++ b/packages/nouns-webapp/src/locales/ja-JP.po
@@ -35,6 +35,10 @@ msgstr "ボディ ({0})"
 msgid "This will clear all previous sponsors and feedback votes"
 msgstr "これにより、以前のすべてのスポンサーとフィードバック投票がクリアされます"
 
+#: src/components/ProposalActionsModal/steps/TransferFundsDetailsStep/index.tsx
+msgid "Edit Token Buyer Top-Up"
+msgstr "Edit Token Buyer Top-Up"
+
 #: src/components/Documentation/index.tsx
 msgid "Because 100% of Noun auction proceeds are sent to Nouns DAO, Nounders have chosen to compensate themselves with Nouns. Every 10th Noun for the first 5 years of the project (Noun ids #0, #10, #20, #30 and so on) will be automatically sent to the Nounder's multisig to be vested and shared among the founding members of the project."
 msgstr "Nounオークションの収益の100%がNouns DAOに送られるため、Nounderは自分達をNounsで補償することに決めました。プロジェクトの最初の5年間の間、毎回10番目のNoun (Noun ID #0, #10, #20, #30 など) が自動的にNoundersのマルチシグに送られ、プロジェクトの創設メンバー達に与えられて、共有されます。"
@@ -611,11 +615,7 @@ msgid "Proposal Executed!"
 msgstr "提案が実行されました！"
 
 #: src/pages/EditProposal/index.tsx
-#: src/pages/EditProposal/index.tsx
 #: src/pages/EditCandidate/index.tsx
-#: src/pages/EditCandidate/index.tsx
-#: src/pages/CreateProposal/index.tsx
-#: src/pages/CreateCandidate/index.tsx
 msgid "Note"
 msgstr "注"
 
@@ -1325,8 +1325,8 @@ msgstr "オークション"
 #: src/pages/EditProposal/index.tsx
 #: src/pages/EditCandidate/index.tsx
 #: src/pages/CreateCandidate/index.tsx
-msgid "Because this proposal contains a USDC fund transfer action we've added an additional ETH transaction to refill the TokenBuyer contract. This action allows to DAO to continue to trustlessly acquire USDC to fund proposals like this."
-msgstr "この提案にはUSDCの資金移動アクションが含まれているため、TokenBuyer契約を補充するために追加のETHトランザクションを追加しました。このアクションにより、DAOはこのような提案を資金提供するためにUSDCを信頼なく取得し続けることができます。"
+#~ msgid "Because this proposal contains a USDC fund transfer action we've added an additional ETH transaction to refill the TokenBuyer contract. This action allows to DAO to continue to trustlessly acquire USDC to fund proposals like this."
+#~ msgstr "この提案にはUSDCの資金移動アクションが含まれているため、TokenBuyer契約を補充するために追加のETHトランザクションを追加しました。このアクションにより、DAOはこのような提案を資金提供するためにUSDCを信頼なく取得し続けることができます。"
 
 #: src/components/ProposalActionsModal/steps/StreamPaymentsReviewStep/index.tsx
 msgid "Stream"
@@ -1692,8 +1692,8 @@ msgid "Forking"
 msgstr "フォーキング"
 
 #: src/pages/CreateProposal/index.tsx
-msgid "Because this proposal contains a USDC fund transfer action we've added an additional additional ETH transaction to refill the TokenBuyer contract. This action allows to continue to trustlessly acquire USDC to fund proposals like this."
-msgstr "この提案にはUSDC資金移動アクションが含まれているため、TokenBuyer契約を補充するために追加のETHトランザクションを追加しました。このアクションにより、このような提案を資金提供するためにUSDCを信頼なく取得し続けることができます。"
+#~ msgid "Because this proposal contains a USDC fund transfer action we've added an additional additional ETH transaction to refill the TokenBuyer contract. This action allows to continue to trustlessly acquire USDC to fund proposals like this."
+#~ msgstr "この提案にはUSDC資金移動アクションが含まれているため、TokenBuyer契約を補充するために追加のETHトランザクションを追加しました。このアクションにより、このような提案を資金提供するためにUSDCを信頼なく取得し続けることができます。"
 
 #. placeholder {0}: createCandidateCost ? formatEther(createCandidateCost) : '0'
 #: src/pages/CreateCandidate/index.tsx

--- a/packages/nouns-webapp/src/locales/pseudo.po
+++ b/packages/nouns-webapp/src/locales/pseudo.po
@@ -30,6 +30,10 @@ msgstr ""
 msgid "This will clear all previous sponsors and feedback votes"
 msgstr ""
 
+#: src/components/ProposalActionsModal/steps/TransferFundsDetailsStep/index.tsx
+msgid "Edit Token Buyer Top-Up"
+msgstr ""
+
 #: src/components/Documentation/index.tsx
 msgid "Because 100% of Noun auction proceeds are sent to Nouns DAO, Nounders have chosen to compensate themselves with Nouns. Every 10th Noun for the first 5 years of the project (Noun ids #0, #10, #20, #30 and so on) will be automatically sent to the Nounder's multisig to be vested and shared among the founding members of the project."
 msgstr ""
@@ -606,11 +610,7 @@ msgid "Proposal Executed!"
 msgstr ""
 
 #: src/pages/EditProposal/index.tsx
-#: src/pages/EditProposal/index.tsx
 #: src/pages/EditCandidate/index.tsx
-#: src/pages/EditCandidate/index.tsx
-#: src/pages/CreateProposal/index.tsx
-#: src/pages/CreateCandidate/index.tsx
 msgid "Note"
 msgstr ""
 
@@ -1320,8 +1320,8 @@ msgstr ""
 #: src/pages/EditProposal/index.tsx
 #: src/pages/EditCandidate/index.tsx
 #: src/pages/CreateCandidate/index.tsx
-msgid "Because this proposal contains a USDC fund transfer action we've added an additional ETH transaction to refill the TokenBuyer contract. This action allows to DAO to continue to trustlessly acquire USDC to fund proposals like this."
-msgstr ""
+#~ msgid "Because this proposal contains a USDC fund transfer action we've added an additional ETH transaction to refill the TokenBuyer contract. This action allows to DAO to continue to trustlessly acquire USDC to fund proposals like this."
+#~ msgstr ""
 
 #: src/components/ProposalActionsModal/steps/StreamPaymentsReviewStep/index.tsx
 msgid "Stream"
@@ -1687,8 +1687,8 @@ msgid "Forking"
 msgstr ""
 
 #: src/pages/CreateProposal/index.tsx
-msgid "Because this proposal contains a USDC fund transfer action we've added an additional additional ETH transaction to refill the TokenBuyer contract. This action allows to continue to trustlessly acquire USDC to fund proposals like this."
-msgstr ""
+#~ msgid "Because this proposal contains a USDC fund transfer action we've added an additional additional ETH transaction to refill the TokenBuyer contract. This action allows to continue to trustlessly acquire USDC to fund proposals like this."
+#~ msgstr ""
 
 #. placeholder {0}: createCandidateCost ? formatEther(createCandidateCost) : '0'
 #: src/pages/CreateCandidate/index.tsx

--- a/packages/nouns-webapp/src/locales/zh-CN.po
+++ b/packages/nouns-webapp/src/locales/zh-CN.po
@@ -30,6 +30,10 @@ msgstr "身体（{0}）"
 msgid "This will clear all previous sponsors and feedback votes"
 msgstr "这将清除所有先前的支持者和反馈投票"
 
+#: src/components/ProposalActionsModal/steps/TransferFundsDetailsStep/index.tsx
+msgid "Edit Token Buyer Top-Up"
+msgstr "Edit Token Buyer Top-Up"
+
 #: src/components/Documentation/index.tsx
 msgid "Because 100% of Noun auction proceeds are sent to Nouns DAO, Nounders have chosen to compensate themselves with Nouns. Every 10th Noun for the first 5 years of the project (Noun ids #0, #10, #20, #30 and so on) will be automatically sent to the Nounder's multisig to be vested and shared among the founding members of the project."
 msgstr "由于 100% 的 Noun 拍卖收入都发往 Nouns DAO，Nounders 决定以 Noun 形式自我补偿。项目头 5 年内的每第 10 个 Noun（ID#0、#10、#20、#30 等）将自动发送到 Nounders 的多签钱包，进行归属并在创始成员间分配。"
@@ -606,11 +610,7 @@ msgid "Proposal Executed!"
 msgstr "提案已执行！"
 
 #: src/pages/EditProposal/index.tsx
-#: src/pages/EditProposal/index.tsx
 #: src/pages/EditCandidate/index.tsx
-#: src/pages/EditCandidate/index.tsx
-#: src/pages/CreateProposal/index.tsx
-#: src/pages/CreateCandidate/index.tsx
 msgid "Note"
 msgstr "注意"
 
@@ -1320,8 +1320,8 @@ msgstr "拍卖"
 #: src/pages/EditProposal/index.tsx
 #: src/pages/EditCandidate/index.tsx
 #: src/pages/CreateCandidate/index.tsx
-msgid "Because this proposal contains a USDC fund transfer action we've added an additional ETH transaction to refill the TokenBuyer contract. This action allows to DAO to continue to trustlessly acquire USDC to fund proposals like this."
-msgstr "由于本提案涉及 USDC 资金转移，我们增加了一笔额外的 ETH 交易来补充 TokenBuyer 合约余额。这项操作旨在确保 DAO 能够继续以无需信任的方式获取 USDC，从而为类似的提案提供资金支持。"
+#~ msgid "Because this proposal contains a USDC fund transfer action we've added an additional ETH transaction to refill the TokenBuyer contract. This action allows to DAO to continue to trustlessly acquire USDC to fund proposals like this."
+#~ msgstr "由于本提案涉及 USDC 资金转移，我们增加了一笔额外的 ETH 交易来补充 TokenBuyer 合约余额。这项操作旨在确保 DAO 能够继续以无需信任的方式获取 USDC，从而为类似的提案提供资金支持。"
 
 #: src/components/ProposalActionsModal/steps/StreamPaymentsReviewStep/index.tsx
 msgid "Stream"
@@ -1687,8 +1687,8 @@ msgid "Forking"
 msgstr "分叉中"
 
 #: src/pages/CreateProposal/index.tsx
-msgid "Because this proposal contains a USDC fund transfer action we've added an additional additional ETH transaction to refill the TokenBuyer contract. This action allows to continue to trustlessly acquire USDC to fund proposals like this."
-msgstr "由于此提案包含 USDC 资金转移操作，我们添加了一个额外的 ETH 交易以补充 TokenBuyer 合约。此操作允许继续无信任地获取 USDC 以资助此类提案。"
+#~ msgid "Because this proposal contains a USDC fund transfer action we've added an additional additional ETH transaction to refill the TokenBuyer contract. This action allows to continue to trustlessly acquire USDC to fund proposals like this."
+#~ msgstr "由于此提案包含 USDC 资金转移操作，我们添加了一个额外的 ETH 交易以补充 TokenBuyer 合约。此操作允许继续无信任地获取 USDC 以资助此类提案。"
 
 #. placeholder {0}: createCandidateCost ? formatEther(createCandidateCost) : '0'
 #: src/pages/CreateCandidate/index.tsx

--- a/packages/nouns-webapp/src/pages/CreateCandidate/index.tsx
+++ b/packages/nouns-webapp/src/pages/CreateCandidate/index.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/strict-boolean-expressions */
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { t } from '@lingui/core/macro';
@@ -52,7 +53,8 @@ const CreateCandidatePage = () => {
   const createCandidateCost = useGetCreateCandidateCost();
   const [showTransactionFormModal, setShowTransactionFormModal] = useState(false);
   const [editingTransactionIndex, setEditingTransactionIndex] = useState<number>();
-  const [editingTransactionState, setEditingTransactionState] = useState<ProposalActionModalState>();
+  const [editingTransactionState, setEditingTransactionState] =
+    useState<ProposalActionModalState>();
   const [isProposePending, setProposePending] = useState(false);
   const { _ } = useLingui();
 
@@ -98,7 +100,10 @@ const CreateCandidatePage = () => {
       });
 
       const previousUSDCValue = proposalTransactions[editingTransactionIndex]?.usdcValue ?? 0;
-      const nextUSDCValue = transactionsArray.reduce((total, txn) => total + (txn.usdcValue ?? 0), 0);
+      const nextUSDCValue = transactionsArray.reduce(
+        (total, txn) => total + (txn.usdcValue ?? 0),
+        0,
+      );
       const editedTransaction = proposalTransactions[editingTransactionIndex];
       const isEditingTokenBuyerTopUp =
         editedTransaction?.address.toLowerCase() === nounsTokenBuyerAddress[chainId].toLowerCase();
@@ -120,15 +125,19 @@ const CreateCandidatePage = () => {
       setEditingTransactionState(undefined);
       setShowTransactionFormModal(false);
     },
-    [chainId, editingTransactionIndex, handleAddProposalAction, proposalTransactions, totalUSDCPayment],
+    [
+      chainId,
+      editingTransactionIndex,
+      handleAddProposalAction,
+      proposalTransactions,
+      totalUSDCPayment,
+    ],
   );
 
   const handleEditProposalAction = useCallback(
     (index: number) => {
       const transaction = proposalTransactions[index];
-      if (
-        transaction?.address.toLowerCase() === nounsTokenBuyerAddress[chainId].toLowerCase()
-      ) {
+      if (transaction?.address.toLowerCase() === nounsTokenBuyerAddress[chainId].toLowerCase()) {
         setIncludeTokenBuyerTopUp(true);
       }
       setEditingTransactionIndex(index);

--- a/packages/nouns-webapp/src/pages/CreateProposal/index.tsx
+++ b/packages/nouns-webapp/src/pages/CreateProposal/index.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/strict-boolean-expressions */
 import type { Hex } from '@/utils/types';
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
@@ -53,7 +54,8 @@ const CreateProposalPage = () => {
   const [isTokenBuyerTopUpManuallyEdited, setIsTokenBuyerTopUpManuallyEdited] = useState(false);
   const [showTransactionFormModal, setShowTransactionFormModal] = useState(false);
   const [editingTransactionIndex, setEditingTransactionIndex] = useState<number>();
-  const [editingTransactionState, setEditingTransactionState] = useState<ProposalActionModalState>();
+  const [editingTransactionState, setEditingTransactionState] =
+    useState<ProposalActionModalState>();
   const [isProposePending, setProposePending] = useState(false);
   const [isProposeOnV1, setIsProposeOnV1] = useState(false);
   const [isV1OptionVisible, setIsV1OptionVisible] = useState(false);
@@ -117,7 +119,10 @@ const CreateProposalPage = () => {
       });
 
       const previousUSDCValue = proposalTransactions[editingTransactionIndex]?.usdcValue ?? 0;
-      const nextUSDCValue = transactionsArray.reduce((total, txn) => total + (txn.usdcValue ?? 0), 0);
+      const nextUSDCValue = transactionsArray.reduce(
+        (total, txn) => total + (txn.usdcValue ?? 0),
+        0,
+      );
       const editedTransaction = proposalTransactions[editingTransactionIndex];
       const isEditingTokenBuyerTopUp =
         editedTransaction?.address.toLowerCase() === nounsTokenBuyerAddress[chainId].toLowerCase();
@@ -139,15 +144,19 @@ const CreateProposalPage = () => {
       setEditingTransactionState(undefined);
       setShowTransactionFormModal(false);
     },
-    [chainId, editingTransactionIndex, handleAddProposalAction, proposalTransactions, totalUSDCPayment],
+    [
+      chainId,
+      editingTransactionIndex,
+      handleAddProposalAction,
+      proposalTransactions,
+      totalUSDCPayment,
+    ],
   );
 
   const handleEditProposalAction = useCallback(
     (index: number) => {
       const transaction = proposalTransactions[index];
-      if (
-        transaction?.address.toLowerCase() === nounsTokenBuyerAddress[chainId].toLowerCase()
-      ) {
+      if (transaction?.address.toLowerCase() === nounsTokenBuyerAddress[chainId].toLowerCase()) {
         setIncludeTokenBuyerTopUp(true);
       }
       setEditingTransactionIndex(index);

--- a/packages/nouns-webapp/src/pages/EditCandidate/index.tsx
+++ b/packages/nouns-webapp/src/pages/EditCandidate/index.tsx
@@ -57,7 +57,8 @@ const EditCandidatePage: React.FC<EditCandidateProps> = () => {
   const [commitMessage, setCommitMessage] = useState<string>('');
   const [showTransactionFormModal, setShowTransactionFormModal] = useState(false);
   const [editingTransactionIndex, setEditingTransactionIndex] = useState<number>();
-  const [editingTransactionState, setEditingTransactionState] = useState<ProposalActionModalState>();
+  const [editingTransactionState, setEditingTransactionState] =
+    useState<ProposalActionModalState>();
   const [isProposePending, setProposePending] = useState(false);
   const { address: account } = useAccount();
   const { updateProposalCandidate, updateProposalCandidateState } = useUpdateProposalCandidate();
@@ -116,7 +117,10 @@ const EditCandidatePage: React.FC<EditCandidateProps> = () => {
       });
 
       const previousUSDCValue = proposalTransactions[editingTransactionIndex]?.usdcValue ?? 0;
-      const nextUSDCValue = transactionsArray.reduce((total, txn) => total + (txn.usdcValue ?? 0), 0);
+      const nextUSDCValue = transactionsArray.reduce(
+        (total, txn) => total + (txn.usdcValue ?? 0),
+        0,
+      );
       const editedTransaction = proposalTransactions[editingTransactionIndex];
       const isEditingTokenBuyerTopUp =
         editedTransaction?.address.toLowerCase() === nounsTokenBuyerAddress[chainId].toLowerCase();
@@ -139,15 +143,19 @@ const EditCandidatePage: React.FC<EditCandidateProps> = () => {
       setShowTransactionFormModal(false);
       setIsProposalEdited(true);
     },
-    [chainId, editingTransactionIndex, handleAddProposalAction, proposalTransactions, totalUSDCPayment],
+    [
+      chainId,
+      editingTransactionIndex,
+      handleAddProposalAction,
+      proposalTransactions,
+      totalUSDCPayment,
+    ],
   );
 
   const handleEditProposalAction = useCallback(
     (index: number) => {
       const transaction = proposalTransactions[index];
-      if (
-        transaction?.address.toLowerCase() === nounsTokenBuyerAddress[chainId].toLowerCase()
-      ) {
+      if (transaction?.address.toLowerCase() === nounsTokenBuyerAddress[chainId].toLowerCase()) {
         setIncludeTokenBuyerTopUp(true);
       }
       setEditingTransactionIndex(index);

--- a/packages/nouns-webapp/src/pages/EditProposal/index.tsx
+++ b/packages/nouns-webapp/src/pages/EditProposal/index.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/strict-boolean-expressions */
 import React, { useCallback, useEffect, useState } from 'react';
 
 import { t } from '@lingui/core/macro';
@@ -58,7 +59,8 @@ const EditProposalPage: React.FC<EditProposalProps> = () => {
   const [isTokenBuyerTopUpManuallyEdited, setIsTokenBuyerTopUpManuallyEdited] = useState(false);
   const [showTransactionFormModal, setShowTransactionFormModal] = useState(false);
   const [editingTransactionIndex, setEditingTransactionIndex] = useState<number>();
-  const [editingTransactionState, setEditingTransactionState] = useState<ProposalActionModalState>();
+  const [editingTransactionState, setEditingTransactionState] =
+    useState<ProposalActionModalState>();
   const [isProposePending, setProposePending] = useState(false);
   const [originalTitleValue, setOriginalTitleValue] = useState('');
   const [originalBodyValue, setOriginalBodyValue] = useState('');
@@ -146,7 +148,10 @@ const EditProposalPage: React.FC<EditProposalProps> = () => {
       });
 
       const previousUSDCValue = proposalTransactions[editingTransactionIndex]?.usdcValue ?? 0;
-      const nextUSDCValue = transactionsArray.reduce((total, txn) => total + (txn.usdcValue ?? 0), 0);
+      const nextUSDCValue = transactionsArray.reduce(
+        (total, txn) => total + (txn.usdcValue ?? 0),
+        0,
+      );
       const editedTransaction = proposalTransactions[editingTransactionIndex];
       const isEditingTokenBuyerTopUp =
         editedTransaction?.address.toLowerCase() === nounsTokenBuyerAddress[chainId].toLowerCase();
@@ -169,15 +174,19 @@ const EditProposalPage: React.FC<EditProposalProps> = () => {
       setShowTransactionFormModal(false);
       setIsProposalEdited(true);
     },
-    [chainId, editingTransactionIndex, handleAddProposalAction, proposalTransactions, totalUSDCPayment],
+    [
+      chainId,
+      editingTransactionIndex,
+      handleAddProposalAction,
+      proposalTransactions,
+      totalUSDCPayment,
+    ],
   );
 
   const handleEditProposalAction = useCallback(
     (index: number) => {
       const transaction = proposalTransactions[index];
-      if (
-        transaction?.address.toLowerCase() === nounsTokenBuyerAddress[chainId].toLowerCase()
-      ) {
+      if (transaction?.address.toLowerCase() === nounsTokenBuyerAddress[chainId].toLowerCase()) {
         setIncludeTokenBuyerTopUp(true);
       }
       setEditingTransactionIndex(index);

--- a/packages/nouns-webapp/src/utils/tokenBuyerContractUtils/tokenBuyer.ts
+++ b/packages/nouns-webapp/src/utils/tokenBuyerContractUtils/tokenBuyer.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/strict-boolean-expressions */
 import { useReadNounsTokenBuyerEthNeeded } from '@/contracts';
 
 export const TOKEN_BUYER_BUFFER_BPS = 1_000n;


### PR DESCRIPTION
Fixes lint and missing translation checks for the token buyer top-up changes.

Verification:
- pnpm lint packages/nouns-webapp/src/components/BrandDropdown/index.tsx packages/nouns-webapp/src/components/BrandTextEntry/index.tsx packages/nouns-webapp/src/components/ProposalActionsModal/index.tsx packages/nouns-webapp/src/components/ProposalActionsModal/steps/FunctionCallEnterArgsStep/index.tsx packages/nouns-webapp/src/components/ProposalActionsModal/steps/TransferFundsDetailsStep/index.tsx packages/nouns-webapp/src/components/ProposalTransactions/index.tsx packages/nouns-webapp/src/components/Proposals/index.tsx packages/nouns-webapp/src/components/TokenBuyerTopUpAlert/index.tsx packages/nouns-webapp/src/hooks/useStreamPaymentTransactions.ts packages/nouns-webapp/src/pages/CreateCandidate/index.tsx packages/nouns-webapp/src/pages/CreateProposal/index.tsx packages/nouns-webapp/src/pages/EditCandidate/index.tsx packages/nouns-webapp/src/pages/EditProposal/index.tsx packages/nouns-webapp/src/utils/tokenBuyerContractUtils/tokenBuyer.ts packages/nouns-webapp/src/wrappers/nounsDao.ts
- pnpm --filter @nouns/webapp -- i18n:extract
- pnpm --filter @nouns/webapp -- i18n:compile --strict
- pnpm --filter @nouns/webapp check