### PR TITLE
Sync master to prod

### DIFF
--- a/packages/nouns-webapp/src/components/Footer.tsx
+++ b/packages/nouns-webapp/src/components/Footer.tsx
@@ -23,6 +23,7 @@ export const Footer = () => {
       category: 'Nouns DAO',
       items: [
         { label: t`Calendar`, url: '/calendar' },
+        { label: t`Propdates`, url: 'https://propdates.nouns.wtf' },
         { label: t`Governance`, url: '/vote' },
         { label: t`Brand Assets`, url: '/brand' },
         { label: t`Playground`, url: '/playground' },

--- a/packages/nouns-webapp/src/components/TokenBuyerTopUpAlert/index.tsx
+++ b/packages/nouns-webapp/src/components/TokenBuyerTopUpAlert/index.tsx
@@ -48,8 +48,7 @@ const TokenBuyerTopUpAlert = ({
   const chainId = defaultChain.id;
   const payerAddress = nounsPayerAddress[chainId];
   const treasuryAddress = nounsTreasuryAddress[chainId];
-  const displayedEth =
-    includeTokenBuyerTopUp && topUpEth && topUpEth !== '0' ? topUpEth : suggestedEth;
+  const displayedEth = includeTokenBuyerTopUp && topUpEth !== undefined ? topUpEth : suggestedEth;
   const displayedEthValue = displayedEth ? BigInt(displayedEth) : 0n;
 
   const { data: payerUSDCBalance } = useReadUsdcBalanceOf({

--- a/packages/nouns-webapp/src/locales/en-US.po
+++ b/packages/nouns-webapp/src/locales/en-US.po
@@ -994,6 +994,10 @@ msgstr "For"
 msgid "Function"
 msgstr "Function"
 
+#: src/components/Footer.tsx
+msgid "Propdates"
+msgstr "Propdates"
+
 #: src/pages/Vote/index.tsx
 msgid "Objection only period"
 msgstr "Objection only period"

--- a/packages/nouns-webapp/src/locales/ja-JP.po
+++ b/packages/nouns-webapp/src/locales/ja-JP.po
@@ -999,6 +999,10 @@ msgstr "賛成"
 msgid "Function"
 msgstr "関数"
 
+#: src/components/Footer.tsx
+msgid "Propdates"
+msgstr "Propdates"
+
 #: src/pages/Vote/index.tsx
 msgid "Objection only period"
 msgstr "異議のみの期間"

--- a/packages/nouns-webapp/src/locales/pseudo.po
+++ b/packages/nouns-webapp/src/locales/pseudo.po
@@ -994,6 +994,10 @@ msgstr ""
 msgid "Function"
 msgstr ""
 
+#: src/components/Footer.tsx
+msgid "Propdates"
+msgstr "Propdates"
+
 #: src/pages/Vote/index.tsx
 msgid "Objection only period"
 msgstr ""

--- a/packages/nouns-webapp/src/locales/zh-CN.po
+++ b/packages/nouns-webapp/src/locales/zh-CN.po
@@ -994,6 +994,10 @@ msgstr "支持"
 msgid "Function"
 msgstr "函数"
 
+#: src/components/Footer.tsx
+msgid "Propdates"
+msgstr "Propdates"
+
 #: src/pages/Vote/index.tsx
 msgid "Objection only period"
 msgstr "仅异议期"

--- a/packages/nouns-webapp/src/pages/CreateCandidate/index.tsx
+++ b/packages/nouns-webapp/src/pages/CreateCandidate/index.tsx
@@ -21,7 +21,10 @@ import ProposalTransactions from '@/components/ProposalTransactions';
 import TokenBuyerTopUpAlert from '@/components/TokenBuyerTopUpAlert';
 import { nounsTokenBuyerAddress } from '@/contracts';
 import Section from '@/layout/Section';
-import { useEthNeeded } from '@/utils/tokenBuyerContractUtils/tokenBuyer';
+import {
+  getTokenBuyerTopUpTransactionEth,
+  useEthNeeded,
+} from '@/utils/tokenBuyerContractUtils/tokenBuyer';
 import { Hex } from '@/utils/types';
 import { defaultChain } from '@/wagmi';
 import { ProposalTransaction, useProposalThreshold } from '@/wrappers/nounsDao';
@@ -45,10 +48,16 @@ const CreateCandidatePage = () => {
   const availableVotes = useUserVotes();
   const proposalThreshold = useProposalThreshold();
   const chainId = defaultChain.id;
+  const tokenBuyerAddress = nounsTokenBuyerAddress[chainId];
   const ethNeeded = useEthNeeded(
-    nounsTokenBuyerAddress[chainId],
+    tokenBuyerAddress ?? '',
     totalUSDCPayment,
-    nounsTokenBuyerAddress[chainId] == undefined || totalUSDCPayment === 0,
+    tokenBuyerAddress == undefined || totalUSDCPayment === 0,
+  );
+  const tokenBuyerTopUpTransactionEth = useMemo(
+    () =>
+      getTokenBuyerTopUpTransactionEth(proposalTransactions, tokenBuyerAddress, tokenBuyerTopUpEth),
+    [proposalTransactions, tokenBuyerAddress, tokenBuyerTopUpEth],
   );
   const createCandidateCost = useGetCreateCandidateCost();
   const [showTransactionFormModal, setShowTransactionFormModal] = useState(false);
@@ -351,7 +360,7 @@ const CreateCandidatePage = () => {
               setIsTokenBuyerTopUpManuallyEdited(false);
             }}
             suggestedEth={ethNeeded}
-            topUpEth={tokenBuyerTopUpEth}
+            topUpEth={tokenBuyerTopUpTransactionEth}
           />
         )}
         <ProposalEditor

--- a/packages/nouns-webapp/src/pages/CreateProposal/index.tsx
+++ b/packages/nouns-webapp/src/pages/CreateProposal/index.tsx
@@ -26,7 +26,10 @@ import config from '@/config';
 import { nounsLegacyTreasuryAddress, nounsTokenBuyerAddress } from '@/contracts';
 import Section from '@/layout/Section';
 import { buildEtherscanHoldingsLink } from '@/utils/etherscan';
-import { useEthNeeded } from '@/utils/tokenBuyerContractUtils/tokenBuyer';
+import {
+  getTokenBuyerTopUpTransactionEth,
+  useEthNeeded,
+} from '@/utils/tokenBuyerContractUtils/tokenBuyer';
 import { defaultChain } from '@/wagmi';
 import {
   ProposalState,
@@ -69,10 +72,16 @@ const CreateProposalPage = () => {
   const { proposeOnTimelockV1, proposeOnTimelockV1State } = useProposeOnTimelockV1();
   const { _ } = useLingui();
   const chainId = defaultChain.id;
+  const tokenBuyerAddress = nounsTokenBuyerAddress[chainId];
   const ethNeeded = useEthNeeded(
-    nounsTokenBuyerAddress[chainId] ?? '',
+    tokenBuyerAddress ?? '',
     totalUSDCPayment,
-    nounsTokenBuyerAddress[chainId] == undefined || totalUSDCPayment === 0,
+    tokenBuyerAddress == undefined || totalUSDCPayment === 0,
+  );
+  const tokenBuyerTopUpTransactionEth = useMemo(
+    () =>
+      getTokenBuyerTopUpTransactionEth(proposalTransactions, tokenBuyerAddress, tokenBuyerTopUpEth),
+    [proposalTransactions, tokenBuyerAddress, tokenBuyerTopUpEth],
   );
   const isDaoGteV3 = useIsDaoGteV3();
   const daoEtherscanLink = buildEtherscanHoldingsLink(
@@ -408,7 +417,7 @@ const CreateProposalPage = () => {
               setIsTokenBuyerTopUpManuallyEdited(false);
             }}
             suggestedEth={ethNeeded}
-            topUpEth={tokenBuyerTopUpEth}
+            topUpEth={tokenBuyerTopUpTransactionEth}
           />
         )}
         <ProposalEditor

--- a/packages/nouns-webapp/src/pages/EditCandidate/index.tsx
+++ b/packages/nouns-webapp/src/pages/EditCandidate/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { t } from '@lingui/core/macro';
 import { useLingui } from '@lingui/react';
@@ -22,7 +22,10 @@ import TokenBuyerTopUpAlert from '@/components/TokenBuyerTopUpAlert';
 import { nounsTokenBuyerAddress } from '@/contracts';
 import Section from '@/layout/Section';
 import { processProposalDescriptionText } from '@/utils/processProposalDescriptionText';
-import { useEthNeeded } from '@/utils/tokenBuyerContractUtils/tokenBuyer';
+import {
+  getTokenBuyerTopUpTransactionEth,
+  useEthNeeded,
+} from '@/utils/tokenBuyerContractUtils/tokenBuyer';
 import { defaultChain } from '@/wagmi';
 import { ProposalDetail, ProposalTransaction, useProposalThreshold } from '@/wrappers/nounsDao';
 import {
@@ -68,10 +71,16 @@ const EditCandidatePage: React.FC<EditCandidateProps> = () => {
   const hasVotes = availableVotes != null && availableVotes > 0;
   const proposalThreshold = useProposalThreshold();
   const chainId = defaultChain.id;
+  const tokenBuyerAddress = nounsTokenBuyerAddress[chainId];
   const ethNeeded = useEthNeeded(
-    nounsTokenBuyerAddress[chainId],
+    tokenBuyerAddress ?? '',
     totalUSDCPayment,
-    nounsTokenBuyerAddress[chainId] == undefined || totalUSDCPayment === 0,
+    tokenBuyerAddress == undefined || totalUSDCPayment === 0,
+  );
+  const tokenBuyerTopUpTransactionEth = useMemo(
+    () =>
+      getTokenBuyerTopUpTransactionEth(proposalTransactions, tokenBuyerAddress, tokenBuyerTopUpEth),
+    [proposalTransactions, tokenBuyerAddress, tokenBuyerTopUpEth],
   );
   const proposal = candidate?.version;
   const updateCandidateCost = useGetUpdateCandidateCost();
@@ -422,7 +431,7 @@ const EditCandidatePage: React.FC<EditCandidateProps> = () => {
               setIsTokenBuyerTopUpManuallyEdited(false);
             }}
             suggestedEth={ethNeeded}
-            topUpEth={tokenBuyerTopUpEth}
+            topUpEth={tokenBuyerTopUpTransactionEth}
           />
         )}
         <ProposalEditor

--- a/packages/nouns-webapp/src/pages/EditProposal/index.tsx
+++ b/packages/nouns-webapp/src/pages/EditProposal/index.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/strict-boolean-expressions */
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { t } from '@lingui/core/macro';
 import { useLingui } from '@lingui/react';
@@ -20,7 +20,10 @@ import ProposalTransactions from '@/components/ProposalTransactions';
 import TokenBuyerTopUpAlert from '@/components/TokenBuyerTopUpAlert';
 import { nounsTokenBuyerAddress } from '@/contracts';
 import Section from '@/layout/Section';
-import { useEthNeeded } from '@/utils/tokenBuyerContractUtils/tokenBuyer';
+import {
+  getTokenBuyerTopUpTransactionEth,
+  useEthNeeded,
+} from '@/utils/tokenBuyerContractUtils/tokenBuyer';
 import { Address, Hex } from '@/utils/types';
 import { defaultChain } from '@/wagmi';
 import {
@@ -85,10 +88,16 @@ const EditProposalPage: React.FC<EditProposalProps> = () => {
     availableVotes && proposalThreshold && availableVotes > proposalThreshold,
   );
   const chainId = defaultChain.id;
+  const tokenBuyerAddress = nounsTokenBuyerAddress[chainId];
   const ethNeeded = useEthNeeded(
-    nounsTokenBuyerAddress[chainId],
+    tokenBuyerAddress ?? '',
     totalUSDCPayment,
-    nounsTokenBuyerAddress[chainId] == undefined || totalUSDCPayment === 0,
+    tokenBuyerAddress == undefined || totalUSDCPayment === 0,
+  );
+  const tokenBuyerTopUpTransactionEth = useMemo(
+    () =>
+      getTokenBuyerTopUpTransactionEth(proposalTransactions, tokenBuyerAddress, tokenBuyerTopUpEth),
+    [proposalTransactions, tokenBuyerAddress, tokenBuyerTopUpEth],
   );
 
   const removeTitleFromDescription = (description: string, title: string) => {
@@ -604,7 +613,7 @@ const EditProposalPage: React.FC<EditProposalProps> = () => {
               setIsTokenBuyerTopUpManuallyEdited(false);
             }}
             suggestedEth={ethNeeded}
-            topUpEth={tokenBuyerTopUpEth}
+            topUpEth={tokenBuyerTopUpTransactionEth}
           />
         )}
         <ProposalEditor

--- a/packages/nouns-webapp/src/utils/tokenBuyerContractUtils/tokenBuyer.ts
+++ b/packages/nouns-webapp/src/utils/tokenBuyerContractUtils/tokenBuyer.ts
@@ -11,3 +11,28 @@ export const useEthNeeded = (address: string, additionalTokens: number, skip?: b
 
   return ethNeeded ? ethNeeded.toString() : undefined;
 };
+
+type TokenBuyerTransaction = {
+  address: string;
+  value?: bigint;
+};
+
+export const isTokenBuyerTopUpTransaction = (
+  transaction: TokenBuyerTransaction | undefined,
+  tokenBuyerAddress: string | undefined,
+) =>
+  transaction !== undefined &&
+  tokenBuyerAddress !== undefined &&
+  transaction.address.toLowerCase() === tokenBuyerAddress.toLowerCase();
+
+export const getTokenBuyerTopUpTransactionEth = (
+  transactions: TokenBuyerTransaction[],
+  tokenBuyerAddress: string | undefined,
+  fallbackEth: string,
+) => {
+  const tokenBuyerTopUp = transactions.find(transaction =>
+    isTokenBuyerTopUpTransaction(transaction, tokenBuyerAddress),
+  );
+
+  return tokenBuyerTopUp === undefined ? fallbackEth : String(tokenBuyerTopUp.value ?? 0n);
+};


### PR DESCRIPTION
  - Sync Token Buyer top-up alert with manually edited top-up transaction values.
  - Add Propdates to the Nouns DAO footer links.